### PR TITLE
Add possibility to disable edison-jobs controller via property

### DIFF
--- a/edison-jobs/src/main/java/de/otto/edison/jobs/controller/JobDefinitionsController.java
+++ b/edison-jobs/src/main/java/de/otto/edison/jobs/controller/JobDefinitionsController.java
@@ -1,30 +1,41 @@
 package de.otto.edison.jobs.controller;
 
-import de.otto.edison.jobs.definition.JobDefinition;
-import de.otto.edison.jobs.repository.JobRepository;
-import de.otto.edison.jobs.service.JobDefinitionService;
+import static java.util.Collections.singletonMap;
+import static java.util.stream.Collectors.toList;
+
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+
+import static de.otto.edison.jobs.controller.JobDefinitionRepresentation.representationOf;
+import static de.otto.edison.jobs.controller.Link.link;
+import static de.otto.edison.jobs.controller.UrlHelper.baseUriOf;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.ResponseBody;
 import org.springframework.web.servlet.ModelAndView;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
-import java.io.IOException;
-import java.time.Duration;
-import java.util.*;
-
-import static de.otto.edison.jobs.controller.JobDefinitionRepresentation.representationOf;
-import static de.otto.edison.jobs.controller.Link.link;
-import static de.otto.edison.jobs.controller.UrlHelper.baseUriOf;
-import static java.util.Collections.singletonMap;
-import static java.util.stream.Collectors.toList;
-import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
-import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import de.otto.edison.jobs.definition.JobDefinition;
+import de.otto.edison.jobs.repository.JobRepository;
+import de.otto.edison.jobs.service.JobDefinitionService;
 
 @Controller
+@ConditionalOnProperty(name = "edison.jobs.web.controller.enabled", havingValue = "true", matchIfMissing = true)
 public class JobDefinitionsController {
 
     public static final String INTERNAL_JOBDEFINITIONS = "/internal/jobdefinitions";

--- a/edison-jobs/src/main/java/de/otto/edison/jobs/controller/JobsController.java
+++ b/edison-jobs/src/main/java/de/otto/edison/jobs/controller/JobsController.java
@@ -1,29 +1,42 @@
 package de.otto.edison.jobs.controller;
 
-import de.otto.edison.jobs.domain.JobInfo;
-import de.otto.edison.jobs.service.JobService;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.beans.factory.annotation.Value;
-import org.springframework.http.HttpStatus;
-import org.springframework.stereotype.Controller;
-import org.springframework.web.bind.annotation.*;
-import org.springframework.web.servlet.ModelAndView;
+import static java.util.stream.Collectors.toList;
 
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import static javax.servlet.http.HttpServletResponse.SC_CONFLICT;
+import static javax.servlet.http.HttpServletResponse.SC_NOT_FOUND;
+import static javax.servlet.http.HttpServletResponse.SC_NO_CONTENT;
+
+import static org.springframework.web.bind.annotation.RequestMethod.DELETE;
+import static org.springframework.web.bind.annotation.RequestMethod.GET;
+import static org.springframework.web.bind.annotation.RequestMethod.POST;
+
+import static de.otto.edison.jobs.controller.JobRepresentation.representationOf;
+import static de.otto.edison.jobs.controller.UrlHelper.baseUriOf;
+
 import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
-import static de.otto.edison.jobs.controller.JobRepresentation.representationOf;
-import static de.otto.edison.jobs.controller.UrlHelper.baseUriOf;
-import static java.util.stream.Collectors.toList;
-import static javax.servlet.http.HttpServletResponse.*;
-import static org.springframework.web.bind.annotation.RequestMethod.*;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.stereotype.Controller;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.ResponseBody;
+import org.springframework.web.servlet.ModelAndView;
+
+import de.otto.edison.jobs.domain.JobInfo;
+import de.otto.edison.jobs.service.JobService;
 
 @Controller
+@ConditionalOnProperty(name = "edison.jobs.web.controller.enabled", havingValue = "true", matchIfMissing = true)
 public class JobsController {
 
     private static final Logger LOG = LoggerFactory.getLogger(JobsController.class);

--- a/edison-service/src/main/resources/templates/fragments/navbar/right.html
+++ b/edison-service/src/main/resources/templates/fragments/navbar/right.html
@@ -10,9 +10,13 @@
         </a>
         <ul class="dropdown-menu">
             <li><a th:href="@{/internal/status}">Status</a></li>
-            <li><a th:href="@{/internal/jobs}">Job Overview</a></li>
-            <li><a th:href="@{/internal/jobdefinitions}">Job Definitions</a></li>
-            <li><a th:href="@{/internal/cacheinfos}">Cache Info</a></li>
+            <li th:if="${@environment.getProperty('edison.jobs.web.controller.enabled') == null or @environment.getProperty('edison.jobs.web.controller.enabled') == 'true'}">
+                <a th:href="@{/internal/jobs}">Job Overview</a>
+            </li>
+            <li th:if="${@environment.getProperty('edison.jobs.web.controller.enabled') == null or @environment.getProperty('edison.jobs.web.controller.enabled') == 'true'}">
+                <a th:href="@{/internal/jobdefinitions}">Job Definitions</a></li>
+            <li>
+                <a th:href="@{/internal/cacheinfos}">Cache Info</a></li>
             <li th:if="${@environment.getProperty('edison.togglz.web.console') == null or @environment.getProperty('edison.togglz.web.console') == 'true'}">
                 <a th:href="@{/internal/toggles/console}">Feature Toggles</a>
             </li>


### PR DESCRIPTION
  - We would like to be able to disable the controllers of edison-jobs, because their are not secured (no authentication required) and not used by our application anyways
  - Obviously the controllers are helpful to must applications, thus we left the default to include the controller
  - If you would like to disable it, set edison.jobs.web.controller.enabled=false in your application.properties