### PR TITLE
Make AbstractRepository.byId() and .matchAll() non final again

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,6 +1,7 @@
 # Release History
 
 ## Current snapshot
+* [edison-mongo] Make AbstractRepository.byId() and AbstractRepository.matchAll() non final again
 
 ## Release 0.75.0
 * [edison-jobs],[edison-mongo] Add setJobStatus and setLastUpdate to JobRepository interface and both

--- a/edison-mongo/src/main/java/de/otto/edison/mongo/AbstractMongoRepository.java
+++ b/edison-mongo/src/main/java/de/otto/edison/mongo/AbstractMongoRepository.java
@@ -133,7 +133,7 @@ public abstract class AbstractMongoRepository<K, V> {
      * @param key the document's key
      * @return query Document
      */
-    protected final Document byId(final K key) {
+    protected Document byId(final K key) {
         return key != null ? new Document(ID, key.toString()) : new Document();
     }
 
@@ -142,7 +142,7 @@ public abstract class AbstractMongoRepository<K, V> {
      *
      * @return query Document
      */
-    protected final Document matchAll() {
+    protected Document matchAll() {
         return new Document();
     }
 


### PR DESCRIPTION
This was a breaking change and some code depends on this behavior. Without being able to override this, you can only save the document ID as a string and not as a MongoDB ObjectId inside the collection. This is a poor design decision and the users of this library should be able to implement a different behavior.