### PR TITLE
Fixed dependency problems with edison-service

### DIFF
--- a/HISTORY.md
+++ b/HISTORY.md
@@ -1,5 +1,11 @@
 # Release History
 
+## release 0.80.0
+* **[edison-service]** Make edison-service independent of other edison packages
+  - This might break your build because you did not write your project dependencies explicitly in
+    your build script. Just add the missing edison packages and everything will be fine.
+* **[edison-cache]** Allow CacheInfoController to be disabled
+
 ## release 0.79.3
 * **[edison-cache]** Allow registering custom built caches via `CacheRegistry` to gather cache metrics
 

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ subprojects {
     // Minor Release: 0.X.0: Additional Features, updates from minor releases in Spring
     // Micro Release: 0.0.X: Bugfixes, non-breaking changes, updates from micro releases in Spring
     // DO NOT FORGET TO DOCUMENT CHANGES IN HISTORY.MD
-    version = '0.79.3'
+    version = '0.80.0-SNAPSHOT'
 
     repositories {
         mavenCentral()

--- a/build.gradle
+++ b/build.gradle
@@ -51,7 +51,7 @@ subprojects {
     // Minor Release: 0.X.0: Additional Features, updates from minor releases in Spring
     // Micro Release: 0.0.X: Bugfixes, non-breaking changes, updates from micro releases in Spring
     // DO NOT FORGET TO DOCUMENT CHANGES IN HISTORY.MD
-    version = '0.80.0-SNAPSHOT'
+    version = '0.80.0'
 
     repositories {
         mavenCentral()

--- a/edison-cache/src/main/java/de/otto/edison/cache/controller/CacheInfoController.java
+++ b/edison-cache/src/main/java/de/otto/edison/cache/controller/CacheInfoController.java
@@ -4,6 +4,7 @@ import de.otto.edison.annotations.Beta;
 import de.otto.edison.cache.configuration.CaffeineCacheConfig;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.actuate.endpoint.CachePublicMetrics;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.http.MediaType;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -29,6 +30,7 @@ import static org.springframework.web.bind.annotation.RequestMethod.GET;
  */
 @Controller
 @Beta
+@ConditionalOnProperty(name = "edison.cache.web.controller.enabled", havingValue = "true", matchIfMissing = true)
 public class CacheInfoController {
 
     @Autowired

--- a/edison-service/build.gradle
+++ b/edison-service/build.gradle
@@ -1,14 +1,5 @@
 
 dependencies {
-    compile project(":edison-core")
-    compile project(":edison-health")
-    compile project(":edison-status")
-    compile project(":edison-jobs")
-    compile project(":edison-metrics")
-    compile project(":edison-cache")
-    compile project(":edison-togglz")
-    compile project(":edison-servicediscovery-client")
-
     compile libs.bootstrap
 
     compile libs.springBootThymeleaf

--- a/edison-service/src/main/resources/templates/fragments/navbar/right.html
+++ b/edison-service/src/main/resources/templates/fragments/navbar/right.html
@@ -9,14 +9,18 @@
             Admin <span class="caret"></span>
         </a>
         <ul class="dropdown-menu">
-            <li><a th:href="@{/internal/status}">Status</a></li>
+            <li>
+                <a th:href="@{/internal/status}">Status</a>
+            </li>
             <li th:if="${@environment.getProperty('edison.jobs.web.controller.enabled') == null or @environment.getProperty('edison.jobs.web.controller.enabled') == 'true'}">
                 <a th:href="@{/internal/jobs}">Job Overview</a>
             </li>
             <li th:if="${@environment.getProperty('edison.jobs.web.controller.enabled') == null or @environment.getProperty('edison.jobs.web.controller.enabled') == 'true'}">
-                <a th:href="@{/internal/jobdefinitions}">Job Definitions</a></li>
-            <li>
-                <a th:href="@{/internal/cacheinfos}">Cache Info</a></li>
+                <a th:href="@{/internal/jobdefinitions}">Job Definitions</a>
+            </li>
+            <li th:if="${@environment.getProperty('edison.cache.web.controller.enabled') == null or @environment.getProperty('edison.cache.web.controller.enabled') == 'true'}">
+                <a th:href="@{/internal/cacheinfos}">Cache Info</a>
+            </li>
             <li th:if="${@environment.getProperty('edison.togglz.web.console') == null or @environment.getProperty('edison.togglz.web.console') == 'true'}">
                 <a th:href="@{/internal/toggles/console}">Feature Toggles</a>
             </li>

--- a/example-jobs/build.gradle
+++ b/example-jobs/build.gradle
@@ -1,6 +1,8 @@
 apply plugin: 'spring-boot'
 
 dependencies {
+    compile project(":edison-jobs")
+    compile project(":edison-togglz")
     compile project(":edison-service")
     //compile project(":edison-jobs-mongo")  // Enable to get persistent job information
 

--- a/example-status/build.gradle
+++ b/example-status/build.gradle
@@ -1,6 +1,7 @@
 apply plugin: 'spring-boot'
 
 dependencies {
+    compile project(":edison-status")
     compile project(":edison-service")
     compile libs.springBootDev
 


### PR DESCRIPTION
Edison-service just provides a small quick navigation, but needs all other packages. This prevents us to omit serveral edison packages, e.g. edison-jobs and edison-cache. I fixed this, so you have to write your dependencies explicitly, but it makes edison more modular.