### PR TITLE
Werte aus Staging- und Color-Header im Status ausliefern

### DIFF
--- a/edison-status/src/main/java/de/otto/edison/status/controller/StatusController.java
+++ b/edison-status/src/main/java/de/otto/edison/status/controller/StatusController.java
@@ -1,10 +1,14 @@
 package de.otto.edison.status.controller;
 
+import de.otto.edison.status.domain.ClusterInfo;
 import de.otto.edison.status.indicator.ApplicationStatusAggregator;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.ModelAndView;
+
+import javax.servlet.http.HttpServletRequest;
 
 import static de.otto.edison.status.controller.StatusRepresentation.statusRepresentationOf;
 import static org.springframework.web.bind.annotation.RequestMethod.GET;
@@ -23,8 +27,8 @@ public class StatusController {
                     "application/json"},
             method = GET
     )
-    public StatusRepresentation getStatusAsJson() {
-        return statusRepresentationOf(aggregator.aggregatedStatus());
+    public StatusRepresentation getStatusAsJson(final HttpServletRequest request) {
+        return statusRepresentationOf(aggregator.aggregatedStatus(), clusterInfoOf(request));
     }
 
     @RequestMapping(
@@ -32,9 +36,16 @@ public class StatusController {
             produces = "text/html",
             method = GET
     )
-    public ModelAndView getStatusAsHtml() {
+    public ModelAndView getStatusAsHtml(final HttpServletRequest request) {
         return new ModelAndView("status", "status", aggregator.aggregatedStatus());
     }
 
+    private ClusterInfo clusterInfoOf(final HttpServletRequest request) {
+        final String staging = request.getHeader("x-staging");
+        final String color = request.getHeader("x-color");
+
+        return ClusterInfo.clusterInfo(StringUtils.isEmpty(staging) ? "undefined" : staging,
+                StringUtils.isEmpty(color) ? "UNDEFINED" : color);
+    }
 }
 

--- a/edison-status/src/main/java/de/otto/edison/status/controller/StatusRepresentation.java
+++ b/edison-status/src/main/java/de/otto/edison/status/controller/StatusRepresentation.java
@@ -20,15 +20,15 @@ public class StatusRepresentation {
     public TeamInfo team;
     public List<ServiceSpec> serviceSpecs;
 
-    private StatusRepresentation(final ApplicationStatus applicationStatus) {
-        this.application = new ApplicationRepresentation(applicationStatus);
+    private StatusRepresentation(final ApplicationStatus applicationStatus, final ClusterInfo clusterInfo) {
+        this.application = new ApplicationRepresentation(applicationStatus, clusterInfo);
         this.system = applicationStatus.system;
         this.team = applicationStatus.team;
         this.serviceSpecs = applicationStatus.serviceSpecs;
     }
 
-    public static StatusRepresentation statusRepresentationOf(final ApplicationStatus status) {
-        return new StatusRepresentation(status);
+    public static StatusRepresentation statusRepresentationOf(final ApplicationStatus status, final ClusterInfo clusterInfo) {
+        return new StatusRepresentation(status, clusterInfo);
     }
 
     private Map<String, ?> statusDetailsOf(final List<StatusDetail> statusDetails) {
@@ -64,13 +64,15 @@ public class StatusRepresentation {
         public String version;
         public String commit;
         public String vcsUrl;
+        public String staging;
+        public String color;
         public Status status;
         public Map<String,?> statusDetails;
 
         public ApplicationRepresentation() {
         }
 
-        private ApplicationRepresentation(final ApplicationStatus applicationStatus) {
+        private ApplicationRepresentation(final ApplicationStatus applicationStatus, final ClusterInfo clusterInfo) {
             this.name = applicationStatus.application.name;
             this.description = applicationStatus.application.description;
             this.group = applicationStatus.application.group;
@@ -78,6 +80,8 @@ public class StatusRepresentation {
             this.version = applicationStatus.vcs.version;
             this.commit = applicationStatus.vcs.commit;
             this.vcsUrl = applicationStatus.vcs.url;
+            this.staging = clusterInfo.staging;
+            this.color = clusterInfo.color;
             this.status = applicationStatus.status;
             this.statusDetails = statusDetailsOf(applicationStatus.statusDetails);
         }

--- a/edison-status/src/main/java/de/otto/edison/status/domain/ClusterInfo.java
+++ b/edison-status/src/main/java/de/otto/edison/status/domain/ClusterInfo.java
@@ -1,0 +1,61 @@
+package de.otto.edison.status.domain;
+
+import com.fasterxml.jackson.annotation.JsonIgnoreProperties;
+import net.jcip.annotations.Immutable;
+
+@Immutable
+@JsonIgnoreProperties(ignoreUnknown = true)
+public class ClusterInfo {
+
+    public final String staging;
+    public final String color;
+
+    private ClusterInfo(final String staging, final String color) {
+        this.staging = staging;
+        this.color = color;
+    }
+
+    public static ClusterInfo clusterInfo(final String staging, final String color) {
+        return new ClusterInfo(staging, color);
+    }
+
+    public String getStaging() {
+        return staging;
+    }
+
+    public String getColor() {
+        return color;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) {
+            return true;
+        }
+        if (o == null || getClass() != o.getClass()) {
+            return false;
+        }
+
+        ClusterInfo that = (ClusterInfo) o;
+
+        if (staging != that.staging) {
+            return false;
+        }
+        return color == that.color;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = staging != null ? staging.hashCode() : 0;
+        result = 31 * result + (color != null ? color.hashCode() : 0);
+        return result;
+    }
+
+    @Override
+    public String toString() {
+        return "ClusterInfo{" +
+                "staging=" + staging +
+                ", color=" + color +
+                '}';
+    }
+}

--- a/edison-status/src/test/java/de/otto/edison/acceptance/api/StatusApi.java
+++ b/edison-status/src/test/java/de/otto/edison/acceptance/api/StatusApi.java
@@ -11,6 +11,9 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.client.RestTemplate;
 
 import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 
 import static java.util.Arrays.asList;
@@ -32,9 +35,15 @@ public class StatusApi extends SpringTestBase {
     }
 
     public static When internal_status_is_retrieved_as(final String mediaType) throws IOException {
-        getResource("http://localhost:8085/teststatus/internal/status", of(mediaType));
-        return When.INSTANCE;
+        return internal_status_is_retrieved_as(mediaType, new HashMap<>());
     }
+
+    public static When internal_status_is_retrieved_as(final String mediaType, final Map<String, List<String>> headers)
+                throws IOException {
+
+            getResource("http://localhost:8085/teststatus/internal/status", of(mediaType), headers);
+            return When.INSTANCE;
+        }
 
     public static HttpStatus the_status_code() {
         return statusCode;
@@ -57,9 +66,18 @@ public class StatusApi extends SpringTestBase {
     }
 
     private static void getResource(final String url, final Optional<String> mediaType) throws IOException {
+        getResource(url, mediaType, new HashMap<>());
+    }
+
+    private static void getResource(final String url, final Optional<String> mediaType,
+            final Map<String, List<String>> requestHeaders) throws IOException {
+
         final HttpHeaders headers = new HttpHeaders();
         if (mediaType.isPresent()) {
             headers.setAccept(asList(parseMediaType(mediaType.get())));
+        }
+        if (requestHeaders != null) {
+            headers.putAll(requestHeaders);
         }
 
         final ResponseEntity<String> responseEntity = restTemplate.exchange(

--- a/edison-status/src/test/java/de/otto/edison/acceptance/status/StatusControllerAcceptanceTest.java
+++ b/edison-status/src/test/java/de/otto/edison/acceptance/status/StatusControllerAcceptanceTest.java
@@ -1,18 +1,28 @@
 package de.otto.edison.acceptance.status;
 
-import de.otto.edison.testsupport.TestServer;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 
-import static de.otto.edison.acceptance.api.StatusApi.*;
+import static de.otto.edison.acceptance.api.StatusApi.internal_is_retrieved_as;
+import static de.otto.edison.acceptance.api.StatusApi.internal_status_is_retrieved_as;
+import static de.otto.edison.acceptance.api.StatusApi.the_response_headers;
+import static de.otto.edison.acceptance.api.StatusApi.the_returned_content;
+import static de.otto.edison.acceptance.api.StatusApi.the_returned_json;
+import static de.otto.edison.acceptance.api.StatusApi.the_status_code;
 import static de.otto.edison.testsupport.dsl.Then.assertThat;
 import static de.otto.edison.testsupport.dsl.Then.then;
 import static de.otto.edison.testsupport.dsl.When.when;
-import static org.hamcrest.Matchers.*;
+import static org.hamcrest.Matchers.contains;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.isEmptyString;
+import static org.hamcrest.Matchers.not;
+import static org.hamcrest.Matchers.startsWith;
 
 public class StatusControllerAcceptanceTest {
 
@@ -38,7 +48,8 @@ public class StatusControllerAcceptanceTest {
 
         then(
                 assertThat(the_status_code().value(), is(200)),
-                assertThat(the_response_headers().get("Content-Type"), contains("application/vnd.otto.monitoring.status+json;charset=UTF-8"))
+                assertThat(the_response_headers().get("Content-Type"),
+                        contains("application/vnd.otto.monitoring.status+json;charset=UTF-8"))
         );
     }
 
@@ -56,15 +67,25 @@ public class StatusControllerAcceptanceTest {
 
     @Test
     public void shouldGetApplicationInfo() throws IOException {
+        final Map<String, List<String>> headers = new HashMap<>();
+        final List<String> staging = new ArrayList<>();
+        headers.put("x-staging", staging);
+        staging.add("productive");
+        final List<String> color = new ArrayList<>();
+        headers.put("x-color", color);
+        color.add("BLU");
+
         when(
-                internal_status_is_retrieved_as("application/json")
+                internal_status_is_retrieved_as("application/json", headers)
         );
 
         then(
                 assertThat(the_returned_json().at("/application/name").asText(), is("test-app")),
                 assertThat(the_returned_json().at("/application/description").asText(), is("desc")),
                 assertThat(the_returned_json().at("/application/environment").asText(), is("test-env")),
-                assertThat(the_returned_json().at("/application/group").asText(), is("test-group"))
+                assertThat(the_returned_json().at("/application/group").asText(), is("test-group")),
+                assertThat(the_returned_json().at("/application/staging").asText(), is("productive")),
+                assertThat(the_returned_json().at("/application/color").asText(), is("BLU"))
         );
 
     }

--- a/edison-status/src/test/java/de/otto/edison/status/controller/StatusRepresentationTest.java
+++ b/edison-status/src/test/java/de/otto/edison/status/controller/StatusRepresentationTest.java
@@ -12,6 +12,7 @@ import java.util.Map;
 import static de.otto.edison.status.controller.StatusRepresentation.statusRepresentationOf;
 import static de.otto.edison.status.domain.ApplicationInfo.applicationInfo;
 import static de.otto.edison.status.domain.ApplicationStatus.applicationStatus;
+import static de.otto.edison.status.domain.ClusterInfo.clusterInfo;
 import static de.otto.edison.status.domain.Status.OK;
 import static de.otto.edison.status.domain.Status.WARNING;
 import static de.otto.edison.status.domain.StatusDetail.statusDetail;
@@ -28,7 +29,8 @@ public class StatusRepresentationTest {
     public void shouldCreateStatusRepresentationWithoutDetails() {
         // given
         final StatusRepresentation json = statusRepresentationOf(
-                applicationStatus(applicationInfo("app", "", "test", "local"), mock(SystemInfo.class), mock(VersionInfo.class), mock(TeamInfo.class), emptyList(), emptyList())
+                applicationStatus(applicationInfo("app", "", "test", "local"), mock(SystemInfo.class), mock(VersionInfo.class), mock(TeamInfo.class), emptyList(), emptyList()),
+                clusterInfo("productive", "BLU")
         );
         // then
         assertThat(json.application.name, is("app"));
@@ -37,10 +39,23 @@ public class StatusRepresentationTest {
     }
 
     @Test
+    public void shouldCreateStatusRepresentationWithClusterInfo() {
+        // given
+        final StatusRepresentation json = statusRepresentationOf(
+                applicationStatus(mock(ApplicationInfo.class), mock(SystemInfo.class), VersionInfo.versionInfo("1.0.0", "0815", "http://example.org/commits/{commit}"), mock(TeamInfo.class), emptyList(), emptyList()),
+                clusterInfo("productive", "BLU")
+        );
+        // then
+        assertThat(json.application.staging, is("productive"));
+        assertThat(json.application.color, is("BLU"));
+    }
+
+    @Test
     public void shouldCreateStatusRepresentationWithVersionInfo() {
         // given
         final StatusRepresentation json = statusRepresentationOf(
-                applicationStatus(mock(ApplicationInfo.class), mock(SystemInfo.class), VersionInfo.versionInfo("1.0.0", "0815", "http://example.org/commits/{commit}"), mock(TeamInfo.class), emptyList(), emptyList())
+                applicationStatus(mock(ApplicationInfo.class), mock(SystemInfo.class), VersionInfo.versionInfo("1.0.0", "0815", "http://example.org/commits/{commit}"), mock(TeamInfo.class), emptyList(), emptyList()),
+                clusterInfo("productive", "BLU")
         );
         // then
         assertThat(json.application.version, is("1.0.0"));
@@ -54,7 +69,8 @@ public class StatusRepresentationTest {
         final StatusRepresentation json = statusRepresentationOf(
                 applicationStatus(mock(ApplicationInfo.class), mock(SystemInfo.class), mock(VersionInfo.class), mock(TeamInfo.class), singletonList(
                         statusDetail("someDetail", WARNING, "detailed warning")), emptyList()
-                )
+                ),
+                clusterInfo("productive", "BLU")
         );
         // then
         assertThat(json.application.status, is(WARNING));
@@ -73,7 +89,8 @@ public class StatusRepresentationTest {
                 applicationStatus(mock(ApplicationInfo.class), mock(SystemInfo.class), mock(VersionInfo.class), mock(TeamInfo.class), asList(
                                 statusDetail("Some Detail", OK, "perfect"),
                                 statusDetail("Some Other Detail", WARNING, "detailed warning", detailMap)), emptyList()
-                )
+                ),
+                clusterInfo("productive", "BLU")
         );
         // then
         assertThat(json.application.status, is(WARNING));


### PR DESCRIPTION
Hallo,

wir benötigen für unser Monitoring-Tool von FT4 die Werte aus den Varnish-Headern "x-staging" und "x-color" im Status-Json. Auch FT1 ist aus dem selben Grund daran interessiert. Seid bitte so nett und übernehmt die Änderung. Die Implementierung ist sehr low-level. Wenn Ihr wollt, kann man das natürlich noch schöner machen.

Gruß,
Jörn Fornfeist