### PR TITLE
[edison-core]: Fix reporting of http request count and time to Graphite.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 use them using `@Cacheable`. For example, this way it is possible, to configure loading caches.
 The new `example-cache` contains a showcase for this. This feature makes the 'old' `CacheRegistry`
 interface obsolete.
+* **[edison-core]** Fix reporting of http request count and time to Graphite
 
 **Deprecations:**
 * **[edison-cache]** The `CacheRegistry` is now deprecated and will be removed in release 2.0.0.

--- a/edison-core/src/main/java/de/otto/edison/metrics/http/HttpMetricsFilter.java
+++ b/edison-core/src/main/java/de/otto/edison/metrics/http/HttpMetricsFilter.java
@@ -19,12 +19,12 @@ import java.io.IOException;
  * @since 0.60.0
  */
 @Component
-public class MetricsFilter implements Filter {
+public class HttpMetricsFilter implements Filter {
 
     private final MetricRegistry metricRegistry;
 
     @Autowired
-    public MetricsFilter(final MetricRegistry metricRegistry) {
+    public HttpMetricsFilter(final MetricRegistry metricRegistry) {
         this.metricRegistry = metricRegistry;
     }
 

--- a/edison-core/src/test/java/de/otto/edison/metrics/http/HttpMetricsFilterTest.java
+++ b/edison-core/src/test/java/de/otto/edison/metrics/http/HttpMetricsFilterTest.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 import static org.mockito.Matchers.anyString;
 import static org.mockito.Mockito.*;
 
-public class MetricsFilterTest {
+public class HttpMetricsFilterTest {
 
     @Test
     public void shouldCountRequestsAndMeasureResponseTimes() throws IOException, ServletException {
@@ -36,7 +36,7 @@ public class MetricsFilterTest {
         when(response.getStatus()).thenReturn(200);
 
         // when
-        new MetricsFilter(metricRegistry).doFilter(request, response, mock(FilterChain.class));
+        new HttpMetricsFilter(metricRegistry).doFilter(request, response, mock(FilterChain.class));
 
         // then
         verify(metricRegistry).counter("counter.http.get.200");
@@ -65,7 +65,7 @@ public class MetricsFilterTest {
         final HttpServletResponse response = mock(HttpServletResponse.class);
 
         // when
-        new MetricsFilter(metricRegistry).doFilter(request, response, filterChain);
+        new HttpMetricsFilter(metricRegistry).doFilter(request, response, filterChain);
 
         // then
         verify(filterChain).doFilter(request, response);

--- a/edison-core/src/test/java/de/otto/edison/metrics/http/MetricsIntegrationTest.java
+++ b/edison-core/src/test/java/de/otto/edison/metrics/http/MetricsIntegrationTest.java
@@ -1,0 +1,47 @@
+package de.otto.edison.metrics.http;
+
+import com.codahale.metrics.Counter;
+import com.codahale.metrics.MetricRegistry;
+import de.otto.edison.acceptance.api.StatusApi;
+import de.otto.edison.testsupport.dsl.Then;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.context.embedded.LocalServerPort;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.http.MediaType;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringRunner;
+
+import java.util.Optional;
+
+import static de.otto.edison.acceptance.api.StatusApi.internal_status_is_retrieved_as;
+import static de.otto.edison.acceptance.api.StatusApi.the_returned_content;
+import static de.otto.edison.acceptance.api.StatusApi.the_status_code;
+import static de.otto.edison.testsupport.dsl.Then.then;
+import static de.otto.edison.testsupport.dsl.When.when;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.hamcrest.Matchers.containsString;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.startsWith;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+public class MetricsIntegrationTest {
+
+    @Test
+    public void shouldReportHttpCountAndTimeToGraphite() throws Exception {
+        MetricRegistry metricRegistry = StatusApi.applicationContext().getBean(MetricRegistry.class);
+        long counterBefore = Optional.ofNullable(metricRegistry.getCounters().get("counter.http.get.200")).orElse(new Counter()).getCount();
+
+        //when
+        internal_status_is_retrieved_as("text/html");
+
+        //then
+        long counterAfter = metricRegistry.getCounters().get("counter.http.get.200").getCount();
+        assertThat(counterAfter - counterBefore).isEqualTo(1);
+        long timerValues = metricRegistry.getTimers().get("timer.http.get").getSnapshot().size();
+        assertThat(timerValues).isEqualTo(1);
+    }
+
+}

--- a/edison-core/src/test/java/de/otto/edison/metrics/http/MetricsIntegrationTest.java
+++ b/edison-core/src/test/java/de/otto/edison/metrics/http/MetricsIntegrationTest.java
@@ -2,36 +2,27 @@ package de.otto.edison.metrics.http;
 
 import com.codahale.metrics.Counter;
 import com.codahale.metrics.MetricRegistry;
+import com.codahale.metrics.Timer;
 import de.otto.edison.acceptance.api.StatusApi;
-import de.otto.edison.testsupport.dsl.Then;
+import org.junit.Before;
 import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.context.embedded.LocalServerPort;
-import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.boot.test.web.client.TestRestTemplate;
-import org.springframework.http.MediaType;
-import org.springframework.http.ResponseEntity;
-import org.springframework.test.context.junit4.SpringRunner;
 
 import java.util.Optional;
 
 import static de.otto.edison.acceptance.api.StatusApi.internal_status_is_retrieved_as;
-import static de.otto.edison.acceptance.api.StatusApi.the_returned_content;
-import static de.otto.edison.acceptance.api.StatusApi.the_status_code;
-import static de.otto.edison.testsupport.dsl.Then.then;
-import static de.otto.edison.testsupport.dsl.When.when;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.hamcrest.Matchers.containsString;
-import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.startsWith;
-import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
 
 public class MetricsIntegrationTest {
 
+    private MetricRegistry metricRegistry;
+
+    @Before
+    public void setUp() throws Exception {
+        metricRegistry = StatusApi.applicationContext().getBean(MetricRegistry.class);
+    }
+
     @Test
-    public void shouldReportHttpCountAndTimeToGraphite() throws Exception {
-        MetricRegistry metricRegistry = StatusApi.applicationContext().getBean(MetricRegistry.class);
+    public void shouldReportHttpCountToGraphite() throws Exception {
         long counterBefore = Optional.ofNullable(metricRegistry.getCounters().get("counter.http.get.200")).orElse(new Counter()).getCount();
 
         //when
@@ -40,8 +31,18 @@ public class MetricsIntegrationTest {
         //then
         long counterAfter = metricRegistry.getCounters().get("counter.http.get.200").getCount();
         assertThat(counterAfter - counterBefore).isEqualTo(1);
-        long timerValues = metricRegistry.getTimers().get("timer.http.get").getSnapshot().size();
-        assertThat(timerValues).isEqualTo(1);
+    }
+
+    @Test
+    public void shouldReportHttpTimeToGraphite() throws Exception {
+        long timerSnapshotSizeBefore = Optional.ofNullable(metricRegistry.getTimers().get("timer.http.get")).orElse(new Timer()).getSnapshot().size();
+
+        //when
+        internal_status_is_retrieved_as("text/html");
+
+        //then
+        long timerSnapshotSizeAfter = metricRegistry.getTimers().get("timer.http.get").getSnapshot().size();
+        assertThat(timerSnapshotSizeAfter - timerSnapshotSizeBefore).isEqualTo(1);
     }
 
 }


### PR DESCRIPTION
- Rename  MetricFilter to HttpMetricFilter, because a bean of same name exists already in spring boot and has higher priority, so that the Edison MetricFilter is never instantiated and used.

Resolves: #80