### PR TITLE
Limit GlobalModelAttributes controller advice to 'de.otto.edison' packages

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -37,7 +37,7 @@ subprojects {
     // DO NOT FORGET TO DOCUMENT CHANGES IN CHANGELOG.md
     //
     // Add a GitHub release for every new release: https://github.com/otto-de/edison-microservice/releases
-    version = '1.2.6'
+    version = '1.2.7'
     group = 'de.otto.edison'
 
     repositories {

--- a/edison-core/src/main/java/de/otto/edison/status/controller/GlobalModelAttributes.java
+++ b/edison-core/src/main/java/de/otto/edison/status/controller/GlobalModelAttributes.java
@@ -6,7 +6,7 @@ import org.springframework.ui.Model;
 import org.springframework.web.bind.annotation.ControllerAdvice;
 import org.springframework.web.bind.annotation.ModelAttribute;
 
-@ControllerAdvice
+@ControllerAdvice(basePackages = "de.otto.edison")
 public class GlobalModelAttributes {
 
     ManagementServerProperties managementServerProperties;

--- a/gradle/dependencies.gradle
+++ b/gradle/dependencies.gradle
@@ -4,8 +4,8 @@
  */
 ext {
     versions = [
-            spring_boot                      : '1.5.8.RELEASE',
-            spring                           : '4.3.8.RELEASE',
+            spring_boot                      : '1.5.9.RELEASE',
+            spring                           : '4.3.14.RELEASE',
             async_http_client                : '2.2.0',
             jcip_annotations                 : '1.0',
             logback_classic                  : '1.2.3',
@@ -15,7 +15,7 @@ ext {
             thymeleaf_layout_dialect         : '2.2.2',
             javax_servlet_api                : '3.1.0',
             togglz                           : '2.4.1.Final',
-            mongodb_driver                   : '3.5.0',
+            mongodb_driver                   : '3.6.1',
             caffeine                         : '2.5.6',
             json_path                        : '2.4.0',
             unboundid_ldapsdk_minimal_edition: '3.2.1'
@@ -23,7 +23,7 @@ ext {
     test_versions = [
             junit       : '4.12',
             hamcrest    : '1.3',
-            mockito_core: '2.10.0',
+            mockito_core: '2.13.0',
             jsonassert  : '1.5.0',
             fongo       : '2.1.0'
     ]


### PR DESCRIPTION
Limit GlobalModelAttributes controller advice to 'de.otto.edison' packages. Updated dependencies to: SpringBoot 1.5.9, Spring 4.3.14, MongoDbDriver 3.6.1, Mockito 2.13.0. Updated edison version to 1.2.7.