### PR TITLE
replace deprecated gradle scopes like compile, testCompile and compil…

### DIFF
--- a/edison-core/build.gradle
+++ b/edison-core/build.gradle
@@ -1,18 +1,20 @@
+apply plugin: 'java-library'
+
 dependencies {
-    compile libraries.aws_sdk_ssm
-    compile libraries.async_http_client
+    implementation libraries.aws_sdk_ssm
+    implementation libraries.async_http_client
 
-    compile libraries.spring_boot_starter_web
-    compile libraries.spring_boot_starter_actuator
-    compile libraries.spring_boot_starter_thymeleaf
-    compile libraries.jcip_annotations
-    compile libraries.logback_classic
-    compile libraries.spring_context_support
-    compile libraries.unboundid_ldapsdk_minimal_edition
+    api libraries.spring_boot_starter_web
+    implementation libraries.spring_boot_starter_actuator
+    implementation libraries.spring_boot_starter_thymeleaf
+    implementation libraries.jcip_annotations
+    implementation libraries.logback_classic
+    implementation libraries.spring_context_support
+    implementation libraries.unboundid_ldapsdk_minimal_edition
 
-    testCompile project(":edison-testsupport")
-    testCompile libraries.aws_sdk_ssm
-    testCompile libraries.async_http_client
+    testImplementation project(":edison-testsupport")
+    testImplementation libraries.aws_sdk_ssm
+    testImplementation libraries.async_http_client
 }
 
 artifacts {

--- a/edison-jobs/build.gradle
+++ b/edison-jobs/build.gradle
@@ -1,16 +1,25 @@
+apply plugin: 'java-library'
+
 dependencies {
-    compile libraries.async_http_client
+    implementation libraries.async_http_client
 
-    compile project(":edison-core")
+    implementation project(":edison-core")
 
-    compileOnly libraries.mongodb_driver
-    compileOnly project(":edison-mongo")
+    implementation libraries.mongodb_driver
+    implementation project(":edison-mongo")
 
-    testCompile project(":edison-mongo")
-    testCompile project(":edison-testsupport")
-    testCompile test_libraries.json_path
-    testCompile test_libraries.jsonassert
-    testCompile test_libraries.embedded_mongo
+    implementation group: 'io.micrometer', name: 'micrometer-core', version: '1.2.0'
+    implementation libraries.jcip_annotations
+    implementation libraries.javax_servlet_api
+    implementation libraries.hibernate_validator
+    implementation libraries.java_validation_api
+    api libraries.spring_boot_starter_web
+
+    testImplementation project(":edison-mongo")
+    testImplementation project(":edison-testsupport")
+    testImplementation test_libraries.json_path
+    testImplementation test_libraries.jsonassert
+    testImplementation test_libraries.embedded_mongo
 }
 
 artifacts {

--- a/edison-mongo/build.gradle
+++ b/edison-mongo/build.gradle
@@ -1,11 +1,17 @@
-dependencies {
-    compile project(":edison-core")
-    compile libraries.spring_boot
-    compile libraries.spring_boot_autoconfigure
-    compile libraries.mongodb_driver
+apply plugin: 'java-library'
 
-    testCompile project(":edison-testsupport")
-    testCompile test_libraries.embedded_mongo
+dependencies {
+    implementation project(":edison-core")
+    implementation libraries.spring_boot
+    implementation libraries.spring_boot_autoconfigure
+    implementation libraries.mongodb_driver
+    implementation libraries.javax_servlet_api
+    implementation libraries.hibernate_validator
+    implementation libraries.java_validation_api
+    implementation "org.slf4j:slf4j-api:1.7.27"
+
+    testImplementation project(":edison-testsupport")
+    testImplementation test_libraries.embedded_mongo
 }
 
 artifacts {

--- a/edison-togglz/build.gradle
+++ b/edison-togglz/build.gradle
@@ -1,26 +1,28 @@
+apply plugin: 'java-library'
+
 dependencies {
-    compile project(":edison-core")
-    compile libraries.togglz_console
-    compile libraries.togglz_spring_web
+    implementation project(":edison-core")
+    api libraries.togglz_console
+    api libraries.togglz_spring_web
 
-    compileOnly libraries.aws_sdk_s3
-    compileOnly libraries.mongodb_driver
-    compileOnly project(":edison-mongo")
+    implementation libraries.aws_sdk_s3
+    implementation libraries.mongodb_driver
+    implementation project(":edison-mongo")
 
-    compile libraries.unboundid_ldapsdk_minimal_edition
+    implementation libraries.unboundid_ldapsdk_minimal_edition
+    implementation libraries.jcip_annotations
 
-    testCompile project(":edison-testsupport")
-    testCompile project(":edison-mongo")
+    testImplementation project(":edison-testsupport")
+    testImplementation project(":edison-mongo")
 
-    testCompile libraries.aws_sdk_s3
-    testCompile test_libraries.embedded_mongo
-    testCompile test_libraries.testcontainers
-    testCompile test_libraries.junit
-    testCompile test_libraries.mockito_core
-    testCompile test_libraries.hamcrest_core
-    testCompile test_libraries.hamcrest_library
-    testCompile test_libraries.spring_boot_starter_test
-
+    testImplementation libraries.aws_sdk_s3
+    testImplementation test_libraries.embedded_mongo
+    testImplementation test_libraries.testcontainers
+    testImplementation test_libraries.junit
+    testImplementation test_libraries.mockito_core
+    testImplementation test_libraries.hamcrest_core
+    testImplementation test_libraries.hamcrest_library
+    testImplementation test_libraries.spring_boot_starter_test
 }
 
 artifacts {

--- a/edison-validation/build.gradle
+++ b/edison-validation/build.gradle
@@ -1,9 +1,11 @@
+apply plugin: 'java-library'
+
 dependencies {
     implementation project(":edison-core")
     implementation libraries.hibernate_validator
     implementation libraries.edison_hal
     implementation libraries.validator_collection
-    implementation libraries.java_validation_api
+    api libraries.java_validation_api
 
     testImplementation project(":edison-testsupport")
     testImplementation test_libraries.rest_assured

--- a/examples/example-jobs/build.gradle
+++ b/examples/example-jobs/build.gradle
@@ -1,11 +1,12 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
-    compile project(":edison-jobs")
+    implementation project(":edison-core")
+    implementation project(":edison-jobs")
 //  compile project(":edison-mongo")  // Enable to get persistent job information
-    compile libraries.async_http_client
+    implementation libraries.async_http_client
 
-    testCompile project(":edison-testsupport")
+    testImplementation project(":edison-testsupport")
 }
 
 artifacts {

--- a/examples/example-oauth/build.gradle
+++ b/examples/example-oauth/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
-    compile project(":edison-oauth")
+    implementation project(":edison-oauth")
 
-    compile libraries.togglz_spring_web
-    testCompile project(":edison-testsupport")
+    implementation libraries.togglz_spring_web
+    testImplementation project(":edison-testsupport")
 }
 
 artifacts {

--- a/examples/example-status/build.gradle
+++ b/examples/example-status/build.gradle
@@ -1,10 +1,13 @@
+apply plugin: 'java-library'
 apply plugin: 'org.springframework.boot'
 
 dependencies {
-    compile project(":edison-core")
-    compile libraries.spring_boot_devtools
+    implementation libraries.spring_boot_starter_actuator
 
-    testCompile project(":edison-testsupport")
+    implementation project(":edison-core")
+    implementation libraries.spring_boot_devtools
+
+    testImplementation project(":edison-testsupport")
 }
 
 artifacts {

--- a/examples/example-togglz-mongo/build.gradle
+++ b/examples/example-togglz-mongo/build.gradle
@@ -1,11 +1,14 @@
 apply plugin: 'org.springframework.boot'
 
 dependencies {
-    compile project(":edison-togglz")
-    compile project(":edison-mongo")
-    compile test_libraries.embedded_mongo // In-Memory impl of MongoDB; not intended for production
+    implementation project(":edison-core")
+    implementation project(":edison-togglz")
+    implementation project(":edison-mongo")
 
-    testCompile project(":edison-testsupport")
+    implementation libraries.mongodb_driver
+    implementation test_libraries.embedded_mongo // In-Memory impl of MongoDB; not intended for production
+
+    testImplementation project(":edison-testsupport")
 }
 
 artifacts {

--- a/examples/example-togglz/build.gradle
+++ b/examples/example-togglz/build.gradle
@@ -1,9 +1,14 @@
+apply plugin: 'java-library'
 apply plugin: 'org.springframework.boot'
 
 dependencies {
-    compile project(":edison-togglz")
+    implementation libraries.spring_boot_starter_actuator
 
-    testCompile project(":edison-testsupport")
+    implementation project(":edison-core")
+    implementation project(":edison-togglz")
+    implementation libraries.spring_boot_starter_web
+
+    testImplementation project(":edison-testsupport")
 }
 
 artifacts {

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-4.10-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-5.5.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
replace deprecated gradle scopes like compile, testCompile and compileOnly with implementation and api scopes according to this blogpost: https://reflectoring.io/gradle-pollution-free-dependencies/