### PR TITLE
Ignore unexpected Authorization scheme in Credentials

### DIFF
--- a/edison-core/src/main/java/de/otto/edison/authentication/Credentials.java
+++ b/edison-core/src/main/java/de/otto/edison/authentication/Credentials.java
@@ -39,11 +39,24 @@ public class Credentials {
         String authorizationHeader = request.getHeader("Authorization");
         if (!StringUtils.isEmpty(authorizationHeader)) {
             String credentials = authorizationHeader.substring(6, authorizationHeader.length());
-            String[] decodedCredentialParts = new String(Base64Utils.decode(credentials.getBytes())).split(":", 2);
-            if (!decodedCredentialParts[0].isEmpty() && !decodedCredentialParts[1].isEmpty()) {
+            Optional<String> decodedCredentials = base64Decode(credentials);
+            String[] decodedCredentialParts = decodedCredentials
+                    .map(s1 -> s1.split(":", 2))
+                    .orElse(new String[0]);
+            if (decodedCredentialParts.length >= 2
+                    && !decodedCredentialParts[0].isEmpty()
+                    && !decodedCredentialParts[1].isEmpty()) {
                 return Optional.of(new Credentials(decodedCredentialParts[0], decodedCredentialParts[1]));
             }
         }
         return Optional.empty();
+    }
+
+    private static Optional<String> base64Decode(String input) {
+        try {
+            return Optional.of(new String(Base64Utils.decode(input.getBytes())));
+        } catch (IllegalArgumentException e) {
+            return Optional.empty();
+        }
     }
 }

--- a/edison-core/src/test/java/de/otto/edison/authentication/CredentialsTest.java
+++ b/edison-core/src/test/java/de/otto/edison/authentication/CredentialsTest.java
@@ -76,6 +76,20 @@ public class CredentialsTest {
     }
 
     @Test
+    public void shouldReturnEmptyCredentialsIfAnotherAuthorizationSchemeThanBasicIsUsed() {
+        // given
+        when(httpServletRequest.getHeader("Authorization"))
+                .thenReturn(
+                        "Token eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c");
+
+        // when
+        final Optional<Credentials> credentials = Credentials.readFrom(httpServletRequest);
+
+        // then
+        assertThat(credentials.isPresent(), is(false));
+    }
+
+    @Test
     public void shouldReturnCorrectCredentialsIfPasswordContainsColons() {
         // given
         mockHttpServletRequestWithAuthentication("user:pass:word");


### PR DESCRIPTION
We were seeing 500 errors due to `IllegalArgumentException`s from `java.util.Base64.Decoder#decode(byte[])`. This was due to the fact that the method was being passed an `Authorization` header not with a `Basic <base64-String>` auth, but another scheme, possibly `Token <JWT-Token>`.  Due to the `substring(6, ...)`, it succeeded at this stage, but then failed in the base64 decode. 

This fix addresses the problem by treating `IllegalArgumentException`s the same as if credentials were empty.