### PR TITLE
add feature groups to toggles representation

### DIFF
--- a/.sdkmanrc
+++ b/.sdkmanrc
@@ -1,0 +1,1 @@
+java=11.0.9.open-adpt

--- a/edison-togglz/src/main/java/de/otto/edison/togglz/controller/FeatureToggleRepresentation.java
+++ b/edison-togglz/src/main/java/de/otto/edison/togglz/controller/FeatureToggleRepresentation.java
@@ -2,6 +2,10 @@ package de.otto.edison.togglz.controller;
 
 import com.fasterxml.jackson.annotation.JsonInclude;
 
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
 import static com.fasterxml.jackson.annotation.JsonInclude.Include.NON_NULL;
 
 @JsonInclude(NON_NULL)
@@ -10,13 +14,19 @@ public class FeatureToggleRepresentation {
     public final String description;
     public final boolean enabled;
     public final String value;
+    public final List<String> groups;
 
-
-    FeatureToggleRepresentation(final String description, final boolean enabled, final String value) {
-        this.description = description;
-        this.enabled = enabled;
-        this.value = value;
+    private FeatureToggleRepresentation(Builder builder) {
+        description = builder.description;
+        enabled = builder.enabled;
+        value = builder.value;
+        groups = builder.groups;
     }
+
+    public static Builder newBuilder() {
+        return new Builder();
+    }
+
 
     @Override
     public boolean equals(Object o) {
@@ -26,8 +36,8 @@ public class FeatureToggleRepresentation {
         FeatureToggleRepresentation that = (FeatureToggleRepresentation) o;
 
         if (enabled != that.enabled) return false;
-        if (description != null ? !description.equals(that.description) : that.description != null) return false;
-        return value != null ? value.equals(that.value) : that.value == null;
+        if (!Objects.equals(description, that.description)) return false;
+        return Objects.equals(value, that.value);
 
     }
 
@@ -46,5 +56,39 @@ public class FeatureToggleRepresentation {
                 ", enabled=" + enabled +
                 ", value='" + value + '\'' +
                 '}';
+    }
+
+    public static final class Builder {
+        private String description;
+        private boolean enabled;
+        private String value;
+        private List<String> groups = new ArrayList<>();
+
+        private Builder() {
+        }
+
+        public Builder withDescription(String val) {
+            description = val;
+            return this;
+        }
+
+        public Builder withEnabled(boolean val) {
+            enabled = val;
+            return this;
+        }
+
+        public Builder withValue(String val) {
+            value = val;
+            return this;
+        }
+
+        public Builder withGroups(List<String> val) {
+            groups = val;
+            return this;
+        }
+
+        public FeatureToggleRepresentation build() {
+            return new FeatureToggleRepresentation(this);
+        }
     }
 }

--- a/edison-togglz/src/main/java/de/otto/edison/togglz/controller/FeatureTogglesRepresentation.java
+++ b/edison-togglz/src/main/java/de/otto/edison/togglz/controller/FeatureTogglesRepresentation.java
@@ -3,8 +3,11 @@ package de.otto.edison.togglz.controller;
 import net.jcip.annotations.Immutable;
 import org.togglz.core.Feature;
 import org.togglz.core.manager.FeatureManager;
+import org.togglz.core.metadata.FeatureGroup;
 
+import java.util.List;
 import java.util.Map;
+import java.util.stream.Collectors;
 
 import static java.util.Arrays.stream;
 import static java.util.stream.Collectors.toMap;
@@ -33,9 +36,13 @@ public class FeatureTogglesRepresentation {
     private FeatureToggleRepresentation toFeatureToggleRepresentation(final Feature feature, FeatureManager featureManager) {
 
         final String label = featureManager.getMetaData(feature).getLabel();
-        return new FeatureToggleRepresentation(
-                label != null ? label : feature.name(),
-                featureManager.getFeatureState(feature).isEnabled(),
-                null);
+        final List<String> featureGroups = featureManager.getMetaData(feature).getGroups().stream()
+                .map(FeatureGroup::getLabel)
+                .collect(Collectors.toList());
+        return FeatureToggleRepresentation.newBuilder()
+                .withDescription(label != null ? label : feature.name())
+                .withGroups(featureGroups)
+                .withEnabled(featureManager.getFeatureState(feature).isEnabled())
+                .build();
     }
 }

--- a/edison-togglz/src/test/java/de/otto/edison/togglz/TestFeatures.java
+++ b/edison-togglz/src/test/java/de/otto/edison/togglz/TestFeatures.java
@@ -8,6 +8,7 @@ public enum TestFeatures implements Feature {
 
     @Label("a test feature toggle")
     TEST_FEATURE,
+    @TestToggleGroup
     TEST_FEATURE_2;
 
     public boolean isActive() {

--- a/edison-togglz/src/test/java/de/otto/edison/togglz/TestToggleGroup.java
+++ b/edison-togglz/src/test/java/de/otto/edison/togglz/TestToggleGroup.java
@@ -1,0 +1,15 @@
+package de.otto.edison.togglz;
+
+import org.togglz.core.annotation.FeatureGroup;
+import org.togglz.core.annotation.Label;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@FeatureGroup
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface TestToggleGroup {
+}

--- a/edison-togglz/src/test/java/de/otto/edison/togglz/UnusedToggleGroup.java
+++ b/edison-togglz/src/test/java/de/otto/edison/togglz/UnusedToggleGroup.java
@@ -1,0 +1,14 @@
+package de.otto.edison.togglz;
+
+import org.togglz.core.annotation.FeatureGroup;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@FeatureGroup
+@Target(ElementType.FIELD)
+@Retention(RetentionPolicy.RUNTIME)
+public @interface UnusedToggleGroup {
+}

--- a/edison-togglz/src/test/java/de/otto/edison/togglz/controller/FeatureTogglesRepresentationTest.java
+++ b/edison-togglz/src/test/java/de/otto/edison/togglz/controller/FeatureTogglesRepresentationTest.java
@@ -6,6 +6,7 @@ import org.junit.jupiter.api.Test;
 import org.togglz.core.manager.FeatureManager;
 import org.togglz.testing.TestFeatureManager;
 
+import java.util.List;
 import java.util.Map;
 
 import static de.otto.edison.togglz.controller.FeatureTogglesRepresentation.togglzRepresentation;
@@ -23,7 +24,10 @@ class FeatureTogglesRepresentationTest {
         testee = togglzRepresentation(featureManager);
 
         final Map<String, FeatureToggleRepresentation> features = testee.features;
-        assertThat(features.get("TEST_FEATURE"), is(new FeatureToggleRepresentation("a test feature toggle", false, null)));
+        assertThat(features.get("TEST_FEATURE"), is(FeatureToggleRepresentation.newBuilder()
+                .withDescription("a test feature toggle")
+                .withEnabled(false)
+                .build()));
     }
 
     @Test
@@ -34,5 +38,18 @@ class FeatureTogglesRepresentationTest {
         final Map<String, FeatureToggleRepresentation> features = testee.features;
         assertThat(features, is(notNullValue()));
         assertThat(features.isEmpty(), is(true));
+    }
+
+    @Test
+    void shouldResolveFeatureGroups() {
+        FeatureManager featureManager = new TestFeatureManager(TestFeatures.class);
+        testee = togglzRepresentation(featureManager);
+
+        final Map<String, FeatureToggleRepresentation> features = testee.features;
+        assertThat(features.get("TEST_FEATURE_2"), is(FeatureToggleRepresentation.newBuilder()
+                .withDescription("TEST_FEATURE_2")
+                .withEnabled(false)
+                .withGroups(List.of("TestToggleGroup"))
+                .build()));
     }
 }


### PR DESCRIPTION
This way the feature groups are visible and may be inspected. For example to detect temporary toggles easier