### PR TITLE
Add feature name to exception message when it cannot be prefetched

### DIFF
--- a/edison-togglz/src/main/java/de/otto/edison/togglz/s3/S3TogglzRepository.java
+++ b/edison-togglz/src/main/java/de/otto/edison/togglz/s3/S3TogglzRepository.java
@@ -65,7 +65,7 @@ public class S3TogglzRepository implements StateRepository {
                 if (featureFromName.isPresent()) {
                     return new CacheEntry(featureStateConverter.retrieveFeatureStateFromS3(featureFromName.get()));
                 }
-                throw new IllegalArgumentException("Can not find feature name");
+                throw new IllegalArgumentException("Can not find feature with name: " + featureName);
             });
         }
     }


### PR DESCRIPTION
Co-authored-by: Elisa Cutrin <ecutrina@thoughtworks.com>
Co-authored-by: Javier Sánchez Rois <javier.sanchezrois@thoughtworks.com>

In order to make debugging easier when we get an error when prefetching features we would like to include the name of the offending feature toggle in the exception message.