### PR TITLE
Feat/validate togglz multiple backends

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,7 @@
 # Release Notes
+## 2.5.3
+* **[edison-togglz]**
+    * add a check that prevents the service to start if both a mongo and an s3 togglz config are applying
 
 ## 2.5.2
 * **[edison-core]**

--- a/edison-togglz/src/main/java/de/otto/edison/togglz/RemoteTogglzConfig.java
+++ b/edison-togglz/src/main/java/de/otto/edison/togglz/RemoteTogglzConfig.java
@@ -1,0 +1,6 @@
+package de.otto.edison.togglz;
+
+import org.togglz.core.repository.StateRepository;
+
+public interface RemoteTogglzConfig {
+}

--- a/edison-togglz/src/main/java/de/otto/edison/togglz/configuration/MongoTogglzConfiguration.java
+++ b/edison-togglz/src/main/java/de/otto/edison/togglz/configuration/MongoTogglzConfiguration.java
@@ -5,6 +5,7 @@ import com.mongodb.client.MongoDatabase;
 import de.otto.edison.mongo.configuration.MongoConfiguration;
 import de.otto.edison.mongo.configuration.MongoProperties;
 import de.otto.edison.togglz.FeatureClassProvider;
+import de.otto.edison.togglz.RemoteTogglzConfig;
 import de.otto.edison.togglz.mongo.MongoTogglzRepository;
 import org.slf4j.Logger;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -21,7 +22,7 @@ import static org.slf4j.LoggerFactory.getLogger;
 @AutoConfigureAfter(MongoConfiguration.class)
 @ConditionalOnProperty(prefix = "edison.togglz", name = "mongo.enabled", havingValue = "true", matchIfMissing = true)
 @ConditionalOnClass(MongoClient.class)
-public class MongoTogglzConfiguration {
+public class MongoTogglzConfiguration implements RemoteTogglzConfig {
 
     private static final Logger LOG = getLogger(MongoTogglzConfiguration.class);
 

--- a/edison-togglz/src/main/java/de/otto/edison/togglz/configuration/S3TogglzConfiguration.java
+++ b/edison-togglz/src/main/java/de/otto/edison/togglz/configuration/S3TogglzConfiguration.java
@@ -2,6 +2,7 @@ package de.otto.edison.togglz.configuration;
 
 import de.otto.edison.togglz.DefaultTogglzConfig;
 import de.otto.edison.togglz.FeatureClassProvider;
+import de.otto.edison.togglz.RemoteTogglzConfig;
 import de.otto.edison.togglz.s3.FeatureStateConverter;
 import de.otto.edison.togglz.s3.S3TogglzRepository;
 import org.slf4j.Logger;
@@ -21,7 +22,7 @@ import software.amazon.awssdk.services.s3.model.ListObjectsRequest;
 @EnableConfigurationProperties(TogglzProperties.class)
 @ConditionalOnProperty(prefix = "edison.togglz", name = "s3.enabled", havingValue = "true")
 @ConditionalOnBean(type = "software.amazon.awssdk.services.s3.S3Client")
-public class S3TogglzConfiguration {
+public class S3TogglzConfiguration implements RemoteTogglzConfig {
 
     private static final Logger LOG = LoggerFactory.getLogger(S3TogglzConfiguration.class);
 

--- a/edison-togglz/src/main/java/de/otto/edison/togglz/configuration/TogglzConfiguration.java
+++ b/edison-togglz/src/main/java/de/otto/edison/togglz/configuration/TogglzConfiguration.java
@@ -3,9 +3,11 @@ package de.otto.edison.togglz.configuration;
 import de.otto.edison.authentication.Credentials;
 import de.otto.edison.togglz.DefaultTogglzConfig;
 import de.otto.edison.togglz.FeatureClassProvider;
+import de.otto.edison.togglz.RemoteTogglzConfig;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.boot.web.servlet.FilterRegistrationBean;
+import org.springframework.context.ApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.togglz.core.Feature;
@@ -21,6 +23,7 @@ import org.togglz.servlet.util.HttpServletRequestHolder;
 import org.togglz.spring.manager.FeatureManagerFactory;
 
 import javax.servlet.http.HttpServletRequest;
+import java.util.Map;
 import java.util.Optional;
 
 @Configuration
@@ -54,6 +57,18 @@ public class TogglzConfiguration {
 
             return new SimpleFeatureUser((credentials.isPresent() ? credentials.get().getUsername() : null), isAdmin);
         };
+    }
+
+    @Bean
+    public Boolean validateRemoteConfigs(ApplicationContext applicationContext) {
+        Map<String, RemoteTogglzConfig> remoteToggleConfigs = applicationContext.getBeansOfType(RemoteTogglzConfig.class);
+
+        if (remoteToggleConfigs.size() > 1) {
+            String names = String.join(",", remoteToggleConfigs.keySet());
+            throw new RuntimeException("multiple remote togglz configs exist, make sure only one of them is used: " + names);
+        }
+
+        return true;
     }
 
     @Bean

--- a/edison-togglz/src/test/java/de/otto/edison/togglz/configuration/TogglzConfigurationTest.java
+++ b/edison-togglz/src/test/java/de/otto/edison/togglz/configuration/TogglzConfigurationTest.java
@@ -1,9 +1,18 @@
 package de.otto.edison.togglz.configuration;
 
+import com.mongodb.client.MongoDatabase;
+import de.otto.edison.mongo.configuration.MongoProperties;
 import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.BeanCreationException;
+import org.springframework.boot.autoconfigure.ImportAutoConfiguration;
+import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.boot.test.util.TestPropertyValues;
 import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import software.amazon.awssdk.services.s3.S3Client;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -11,11 +20,34 @@ import static org.hamcrest.Matchers.is;
 public class TogglzConfigurationTest {
 
     private final AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+    private final static MongoDatabase mockMongoDatabase = Mockito.mock(MongoDatabase.class);
+    private final static S3Client s3Client = Mockito.mock(S3Client.class);
 
     @AfterEach
     public void close() {
         if (this.context != null) {
             this.context.close();
+        }
+    }
+
+    @ImportAutoConfiguration({S3TogglzConfiguration.class, TogglzConfiguration.class,
+            InMemoryFeatureStateRepositoryConfiguration.class,
+            MongoAndS3TestConfiguration.class,
+            MongoProperties.class,
+            MongoTogglzConfiguration.class})
+    private static class MultipleTogglzConfigsAutoConfiguration {
+    }
+
+    @TestConfiguration
+    static class MongoAndS3TestConfiguration {
+        @Bean
+        public MongoDatabase mongoDatabase() {
+            return mockMongoDatabase;
+        }
+
+        @Bean
+        public S3Client s3Client() {
+            return s3Client;
         }
     }
 
@@ -31,6 +63,45 @@ public class TogglzConfigurationTest {
         assertThat(this.context.containsBean("userProvider"), is(true));
         assertThat(this.context.containsBean("togglzConfig"), is(true));
         assertThat(this.context.containsBean("featureManager"), is(true));
+    }
+
+    @Test
+    public void shouldThrowExceptionOnMultipleBackendConfigs() {
+        //given
+        this.context.register(MultipleTogglzConfigsAutoConfiguration.class);
+        this.context.register(MongoAndS3TestConfiguration.class);
+
+        TestPropertyValues
+                .of("edison.togglz.s3.enabled=true")
+                .and("edison.togglz.s3.bucket-name=togglz-bucket")
+                .and("edison.togglz.s3.check-bucket=true")
+                .and("edison.mongo.db=db")
+                .and("edison.mongo.user=test")
+                .and("edison.mongo.password=test")
+                .applyTo(context);
+
+        //expect
+        Assertions.assertThrows(BeanCreationException.class, this.context::refresh);
+    }
+
+    @Test
+    public void shouldAllowSingleBackendConfig() {
+        //given
+        this.context.register(MultipleTogglzConfigsAutoConfiguration.class);
+        this.context.register(MongoAndS3TestConfiguration.class);
+
+        TestPropertyValues
+                .of("edison.togglz.s3.enabled=true")
+                .and("edison.togglz.s3.bucket-name=togglz-bucket")
+                .and("edison.togglz.s3.check-bucket=true")
+                .and("edison.togglz.mongo.enabled=false")
+                .and("edison.mongo.db=db")
+                .and("edison.mongo.user=test")
+                .and("edison.mongo.password=test")
+                .applyTo(context);
+
+        //expect
+        this.context.refresh();
     }
 
 }


### PR DESCRIPTION
This fixes #261 by checking if both a mongo togglz configuration and an s3 togglz configuration applies.
This can be case if the microservice itself uses mongo db but the feature toggles are backed by s3.