### PR TITLE
Add `-parameters` parameter

### DIFF
--- a/gradle/compile.gradle
+++ b/gradle/compile.gradle
@@ -3,5 +3,5 @@ apply plugin: 'java'
 tasks.withType(JavaCompile) {
     dependsOn processResources
     options.encoding = 'UTF-8'
-    options.compilerArgs << '-Xlint:all,-serial,-processing'
+    options.compilerArgs << '-Xlint:all,-serial,-processing,-parameters'
 }


### PR DESCRIPTION
Add `-parameters` parameter to suppress spring boot warning message:
```
2023-06-20T15:08:00,132 WARN  logger=LocalVariableTableParameterNameDiscoverer message='Using deprecated '-debug' fallback for parameter name resolution. Compile the affected code with '-parameters' instead or avoid its introspection: de.otto.edison.logging.ui.LoggersHtmlEndpoint' url= thread=main 
```