### PR TITLE
add separator-option in paramstore post processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Release Notes
 
+## 3.2.1
+* **[edison-core]**
+    * Add seperator-option to use sections in a parameter name as properties e.g. `some/value` results in `some.value` with a seperator of `/`
+
 ## 3.2.0
 * **[all]**
   * Spring Boot 3.2.2

--- a/edison-core/src/main/java/de/otto/edison/env/ParamStoreProperties.java
+++ b/edison-core/src/main/java/de/otto/edison/env/ParamStoreProperties.java
@@ -8,6 +8,8 @@ public class ParamStoreProperties {
     private String path;
     private boolean addWithLowestPrecedence;
 
+    private String separator;
+
     public ParamStoreProperties() {
     }
 
@@ -33,5 +35,14 @@ public class ParamStoreProperties {
 
     public void setAddWithLowestPrecedence(final boolean addWithLowestPrecedence) {
         this.addWithLowestPrecedence = addWithLowestPrecedence;
+    }
+
+
+    public String getSeparator() {
+        return separator;
+    }
+
+    public void setSeparator(String separator) {
+        this.separator = separator;
     }
 }

--- a/edison-core/src/main/java/de/otto/edison/env/ParamStorePropertySourcePostProcessor.java
+++ b/edison-core/src/main/java/de/otto/edison/env/ParamStorePropertySourcePostProcessor.java
@@ -73,7 +73,10 @@ public class ParamStorePropertySourcePostProcessor implements BeanFactoryPostPro
 
     private void addParametersToPropertiesSource(final Properties propertiesSource, final List<Parameter> parameters) {
         parameters.forEach(p -> {
-            final String name = p.name().substring(properties.getPath().length() + 1);
+            String name = p.name().substring(properties.getPath().length() + 1);
+            if (StringUtils.hasText(properties.getSeparator())) {
+                name = name.replaceAll(properties.getSeparator(), ".");
+            }
             final String loggingValue = SECURE_STRING == p.type() ? "*****" : p.value();
             LOG.info("Loaded '" + name + "' from ParametersStore, value='" + loggingValue + "', length=" + p.value().length());
 
@@ -87,6 +90,7 @@ public class ParamStorePropertySourcePostProcessor implements BeanFactoryPostPro
         final String path = requireNonNull(environment.getProperty(pathProperty),
                 "Property '" + pathProperty + "' must not be null");
         properties = new ParamStoreProperties();
+        properties.setSeparator(environment.getProperty("edison.env.paramstore.separator"));
         properties.setAddWithLowestPrecedence(
                 parseBoolean(environment.getProperty("edison.env.paramstore.addWithLowestPrecedence", "false")));
         properties.setPath(path);

--- a/edison-core/src/test/java/de/otto/edison/env/ParamStorePropertySourcePostProcessorTest.java
+++ b/edison-core/src/test/java/de/otto/edison/env/ParamStorePropertySourcePostProcessorTest.java
@@ -35,7 +35,10 @@ class ParamStorePropertySourcePostProcessorTest {
             SsmClient mock = mock(SsmClient.class);
             when(mock.getParametersByPath(any(GetParametersByPathRequest.class))).thenReturn(
                     GetParametersByPathResponse.builder()
-                            .parameters(Parameter.builder().name("mongo/password").value("secret").build())
+                            .parameters(
+                                    Parameter.builder().name("mongo/password").value("secret").build(),
+                                    Parameter.builder().name("mongo/subSection/config").value("someConfig").build()
+                            )
                             .build()
             );
             return mock;
@@ -59,6 +62,21 @@ class ParamStorePropertySourcePostProcessorTest {
         assertThat(this.context.containsBean("paramStorePropertySourcePostProcessor"), is(true));
         assertThat(this.context.getEnvironment().getPropertySources().contains("paramStorePropertySource"), is(true));
         assertEquals("secret", this.context.getEnvironment().getProperty("password"));
+        assertEquals("someConfig", this.context.getEnvironment().getProperty("subSection/config"));
+    }
+
+    @Test
+    void shouldLoadPropertiesWithSeperatorsFromParamStore() {
+        this.context.register(ParamStoreTestConfiguration.class);
+        TestPropertyValues
+                .of("edison.env.paramstore.enabled=true")
+                .and("edison.env.paramstore.path=mongo")
+                .and("edison.env.paramstore.separator=/")
+                .applyTo(context);
+        this.context.refresh();
+        assertThat(this.context.containsBean("paramStorePropertySourcePostProcessor"), is(true));
+        assertThat(this.context.getEnvironment().getPropertySources().contains("paramStorePropertySource"), is(true));
+        assertEquals("someConfig", this.context.getEnvironment().getProperty("subSection.config"));
     }
 
     @Test


### PR DESCRIPTION
Hi,

we do have parameters that are named the following way:
`/some/service/subSection/config`

The existing setup requires application-properties to be `subSection/config` which do not represent the standard way of accessing properties with structures.

I suggest introducing a separator option helping to resolve this issue.
This way our example would result in `subSection.config`

Thanks