### PR TITLE
add local-option to support an initial togglz state based on properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Release Notes
 
+## 3.4.5
+* **[edison-togglz]** add `local` option to support an initial togglz state based on properties
+
 ## 3.4.4
 * **[all]**: Update to Spring Boot 3.4.5
 * **[all]**: Dependency Updates

--- a/edison-togglz/build.gradle
+++ b/edison-togglz/build.gradle
@@ -4,6 +4,7 @@ dependencies {
     implementation project(":edison-core")
     api libraries.togglz_console
     api libraries.togglz_spring_web
+    api libraries.togglz_spring_boot_starter
 
     implementation libraries.aws_sdk_s3
     implementation libraries.mongodb_driver_core

--- a/edison-togglz/src/main/java/de/otto/edison/togglz/configuration/LocalTogglzConfiguration.java
+++ b/edison-togglz/src/main/java/de/otto/edison/togglz/configuration/LocalTogglzConfiguration.java
@@ -1,0 +1,50 @@
+package de.otto.edison.togglz.configuration;
+
+import de.otto.edison.togglz.RemoteTogglzConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.boot.context.properties.bind.Bindable;
+import org.springframework.boot.context.properties.bind.Binder;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.togglz.core.repository.StateRepository;
+import org.togglz.core.repository.property.PropertyBasedStateRepository;
+import org.togglz.spring.boot.actuate.autoconfigure.PropertiesPropertySource;
+
+import java.util.Collections;
+import java.util.Map;
+import java.util.Properties;
+
+@Configuration
+@EnableConfigurationProperties(TogglzProperties.class)
+@ConditionalOnProperty(prefix = "edison.togglz", name = "local.enabled", havingValue = "true")
+public class LocalTogglzConfiguration implements RemoteTogglzConfig {
+
+    private static final Logger LOG = LoggerFactory.getLogger(LocalTogglzConfiguration.class);
+
+    @Bean
+    public StateRepository stateRepository(ApplicationContext applicationContext) {
+        LOG.info("========================");
+        LOG.info("Using PropertyBasedStateRepository");
+        LOG.info("========================");
+
+        Properties featureProperties = getPropertiesFromFeaturesPrefix(applicationContext);
+
+        PropertiesPropertySource propertySource = new PropertiesPropertySource(featureProperties);
+        return new PropertyBasedStateRepository(propertySource);
+    }
+
+    private static Properties getPropertiesFromFeaturesPrefix(ApplicationContext applicationContext) {
+        Properties props = new Properties();
+        Map<String, String> propsAsMap = Binder.get(applicationContext.getEnvironment())
+                .bind("edison.togglz.local.features", Bindable.mapOf(String.class, String.class))
+                .orElse(Collections.emptyMap());
+        for (Map.Entry<String, String> entry : propsAsMap.entrySet()) {
+            props.setProperty(entry.getKey(), entry.getValue());
+        }
+        return props;
+    }
+}

--- a/edison-togglz/src/test/java/de/otto/edison/acceptance/togglz/LocalTogglzAcceptanceTest.java
+++ b/edison-togglz/src/test/java/de/otto/edison/acceptance/togglz/LocalTogglzAcceptanceTest.java
@@ -1,0 +1,67 @@
+package de.otto.edison.acceptance.togglz;
+
+import de.otto.edison.togglz.DefaultTogglzConfig;
+import de.otto.edison.togglz.TestFeatures;
+import de.otto.edison.togglz.TestServer;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.context.annotation.Profile;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.ContextConfiguration;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+import org.togglz.core.manager.FeatureManager;
+import org.togglz.core.manager.TogglzConfig;
+import org.togglz.core.repository.FeatureState;
+import org.togglz.core.repository.StateRepository;
+import org.togglz.core.user.NoOpUserProvider;
+
+import static de.otto.edison.testsupport.dsl.Then.assertThat;
+import static org.hamcrest.Matchers.is;
+import static org.springframework.boot.test.context.SpringBootTest.WebEnvironment.RANDOM_PORT;
+
+@ActiveProfiles("test")
+@ExtendWith(SpringExtension.class)
+@SpringBootTest(webEnvironment = RANDOM_PORT, classes = {TestServer.class})
+@TestPropertySource
+        (properties = {
+                "edison.togglz.local.enabled=true",
+                "edison.togglz.local.features.TEST_FEATURE=true"
+        })
+@ContextConfiguration(classes = {LocalTogglzAcceptanceTest.TogglzConfiguration.class})
+public class LocalTogglzAcceptanceTest {
+
+    @Autowired
+    private FeatureManager featureManager;
+
+
+    @Test
+    public void shouldGetTheCorrectFeatureStateFromProperties() {
+        // when
+        FeatureState featureStateFeature1 = featureManager.getFeatureState(TestFeatures.TEST_FEATURE);
+        FeatureState featureStateFeature2 = featureManager.getFeatureState(TestFeatures.TEST_FEATURE_2);
+
+        // then
+        assertThat(featureStateFeature1.isEnabled(), is(true));
+        assertThat(featureStateFeature2.isEnabled(), is(false));
+    }
+
+    @Configuration
+    static class TogglzConfiguration{
+
+        @Bean
+        @Profile("test")
+        public TogglzConfig togglzConfig(StateRepository stateRepository) {
+            return new DefaultTogglzConfig(
+                    stateRepository,
+                    new NoOpUserProvider(),
+                    () ->TestFeatures.class
+            );
+        }
+
+    }
+}


### PR DESCRIPTION
This offers the opportunity to have a local initial local togglz state without using the @EnabledByDefault annotation. This helps speeding up local development so you do not need to manually enable features under test anymore.
 
Please have a look.
 
The config would be as follows:
```
edison:
    togglz:
        local:
            enabled: true
            features:
                FEATURE_UNDER_DEVELOPMENT: true
```