### PR TITLE
fix: handle epoch milliseconds in DateTimeUtil.parse()

### DIFF
--- a/edison-core/src/main/java/de/otto/edison/util/DateTimeUtil.java
+++ b/edison-core/src/main/java/de/otto/edison/util/DateTimeUtil.java
@@ -1,12 +1,15 @@
 package de.otto.edison.util;
 
+import java.time.Instant;
 import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
 import java.time.format.DateTimeFormatter;
 import java.time.format.DateTimeFormatterBuilder;
 
 /**
  * Utility for parsing date-time strings that may use different offset formats,
- * e.g. "+02:00" (ISO-8601) or "+0200" (as produced by git-commit-id-plugin).
+ * e.g. "+02:00" (ISO-8601) or "+0200" (as produced by git-commit-id-plugin),
+ * or epoch milliseconds (as produced by Spring Boot's {@code GitProperties} coercion).
  */
 public final class DateTimeUtil {
 
@@ -29,13 +32,20 @@ public final class DateTimeUtil {
     private DateTimeUtil() {}
 
     /**
-     * Parses a date-time string to {@link OffsetDateTime}, tolerating both
-     * {@code +0200} and {@code +02:00} offset styles. Returns {@code null}
-     * for {@code null} or empty input instead of throwing.
+     * Parses a date-time string to {@link OffsetDateTime}. Handles:
+     * <ul>
+     *   <li>Epoch milliseconds (e.g. {@code "1747827915000"}) — as returned by Spring Boot's
+     *       {@code GitProperties} coercion of {@code commit.time}. Interpreted as UTC.</li>
+     *   <li>ISO date-time with {@code +0200} or {@code +02:00} offset styles.</li>
+     * </ul>
+     * Returns {@code null} for {@code null} or empty input instead of throwing.
      */
     public static OffsetDateTime parse(final String dateTime) {
         if (dateTime == null || dateTime.isEmpty()) {
             return null;
+        }
+        if (dateTime.chars().allMatch(Character::isDigit)) {
+            return OffsetDateTime.ofInstant(Instant.ofEpochMilli(Long.parseLong(dateTime)), ZoneOffset.UTC);
         }
         return OffsetDateTime.parse(dateTime, LENIENT_FORMATTER);
     }

--- a/edison-core/src/test/java/de/otto/edison/util/DateTimeUtilTest.java
+++ b/edison-core/src/test/java/de/otto/edison/util/DateTimeUtilTest.java
@@ -45,6 +45,11 @@ class DateTimeUtilTest {
                         "ISO-8601 with UTC Z",
                         "2026-03-31T08:47:00Z",
                         OffsetDateTime.of(2026, 3, 31, 8, 47, 0, 0, ZoneOffset.UTC)
+                ),
+                arguments(
+                        "epoch milliseconds — as coerced by Spring Boot GitProperties",
+                        "1743404778000",
+                        OffsetDateTime.of(2025, 3, 31, 7, 6, 18, 0, ZoneOffset.UTC)
                 )
         );
     }


### PR DESCRIPTION
Fixes #2271

## Problem

`/internal/status` throws a 500 with a `TemplateInputException` when the app is started with Spring Boot's `GitProperties` auto-configuration.

## Root Cause

Spring Boot's `GitProperties` constructor calls `coercePropertyToEpoch()` on the `commit.time` property. This converts the ISO date string (e.g. `2026-05-21T12:25:15+0200`) to **epoch milliseconds** (e.g. `1747827915000`) and stores it back.

`VersionInfo` reads this coerced value via `gitProperties.get("commit.time")`. The `date-time-badge` fragment in `status.html` then calls `DateTimeUtil.parse("1747827915000")`, which throws a `DateTimeParseException` because only ISO datetime formats were handled — crashing the template.

## Fix

In `DateTimeUtil.parse()`, check whether the input consists entirely of digits before attempting ISO parsing. If it does, interpret it as epoch milliseconds (UTC).

```java
if (dateTime.chars().allMatch(Character::isDigit)) {
    return OffsetDateTime.ofInstant(Instant.ofEpochMilli(Long.parseLong(dateTime)), ZoneOffset.UTC);
}
```

A corresponding test case was added for the epoch milliseconds format.