### PR TITLE
fix: gracefully handle invalid date strings in DateTimeUtil.parse()

### DIFF
--- a/edison-core/src/main/java/de/otto/edison/util/DateTimeUtil.java
+++ b/edison-core/src/main/java/de/otto/edison/util/DateTimeUtil.java
@@ -41,12 +41,19 @@ public final class DateTimeUtil {
      * Returns {@code null} for {@code null} or empty input instead of throwing.
      */
     public static OffsetDateTime parse(final String dateTime) {
-        if (dateTime == null || dateTime.isEmpty()) {
+        try {
+
+            if (dateTime == null || dateTime.isEmpty()) {
+                return null;
+            }
+
+            if (dateTime.chars().allMatch(Character::isDigit)) {
+                return OffsetDateTime.ofInstant(Instant.ofEpochMilli(Long.parseLong(dateTime)), ZoneOffset.UTC);
+            }
+            return OffsetDateTime.parse(dateTime, LENIENT_FORMATTER);
+
+        } catch (final Exception e) {
             return null;
         }
-        if (dateTime.chars().allMatch(Character::isDigit)) {
-            return OffsetDateTime.ofInstant(Instant.ofEpochMilli(Long.parseLong(dateTime)), ZoneOffset.UTC);
-        }
-        return OffsetDateTime.parse(dateTime, LENIENT_FORMATTER);
     }
 }

--- a/edison-core/src/main/resources/templates/fragments/widgets/date-time-badge.html
+++ b/edison-core/src/main/resources/templates/fragments/widgets/date-time-badge.html
@@ -7,7 +7,7 @@
      th:with="parsed=${T(de.otto.edison.util.DateTimeUtil).parse(dateTime)},
                formatted=${parsed != null} ? ${#temporals.format(parsed, 'dd.MM.yyyy HH:mm:ss')} : '',
                offset=${parsed != null} ? ${parsed.offset.id} : ''">
-    <div th:text="${parsed != null} ? ${formatted} : ''"></div>
+    <div th:text="${parsed != null} ? ${formatted} : ${dateTime}"></div>
 
     <div class="badge text-bg-secondary"
          th:if="${parsed != null}"

--- a/edison-core/src/test/java/de/otto/edison/util/DateTimeUtilTest.java
+++ b/edison-core/src/test/java/de/otto/edison/util/DateTimeUtilTest.java
@@ -59,4 +59,20 @@ class DateTimeUtilTest {
     void shouldParseKnownFormats(String description, String input, OffsetDateTime expected) {
         assertEquals(expected, DateTimeUtil.parse(input));
     }
+
+    static Stream<Arguments> invalidFormats() {
+        return Stream.of(
+                arguments("plain text", "not-a-date"),
+                arguments("date without time", "2026-03-31"),
+                arguments("incomplete ISO datetime", "2026-03-31T"),
+                arguments("datetime with invalid offset", "2026-03-31T08:47:00+99:99"),
+                arguments("mixed digits and letters", "12345abc")
+        );
+    }
+
+    @ParameterizedTest(name = "{0}")
+    @MethodSource("invalidFormats")
+    void shouldReturnNullForInvalidInput(String description, String input) {
+        assertNull(DateTimeUtil.parse(input));
+    }
 }


### PR DESCRIPTION
`DateTimeUtil.parse()` previously threw an exception for invalid or unparseable                                                                                                                          date strings instead of returning `null`.                             
                                                                                           
### Changes    
                                                                                                                                                                                            
- Wrapped parse logic in try-catch to return `null` for any invalid input                                                                                                                                 

- `date-time-badge.html` now falls back to displaying the raw value instead                                                                                                                               
       of an empty string when parsing fails                                                                                                                                                                   

- Added parameterized tests covering invalid input formats 