### PR TITLE
Improve job message log

### DIFF
--- a/edison-jobs/src/main/resources/static/internal/js/logLoader.js
+++ b/edison-jobs/src/main/resources/static/internal/js/logLoader.js
@@ -1,5 +1,7 @@
 import {formatUTCToLocalTime, formatUTCToLocalDateTime, formatInitialDates} from './datetime.js'
 
+let followLog = true;
+
 export function getLog(logIndex) {
     $.ajax({
         type: "GET",
@@ -38,7 +40,7 @@ export function getLog(logIndex) {
                 logIndex++;
             }
 
-            if ($('#follow-log').prop('checked')) {
+            if (followLog) {
                 logWindow.each(function () {
                     const scrollHeight = Math.max(this.scrollHeight, this.clientHeight);
                     this.scrollTop = scrollHeight - this.clientHeight;
@@ -74,12 +76,36 @@ export function getLog(logIndex) {
 }
 
 if (typeof window !== 'undefined' && !window.__testing__) {
-    //Uncheck follow log checkbox if real mouse scrolling detected
     $(".logWindow").bind("scroll mousedown DOMMouseScroll mousewheel keyup", function (e) {
-        if (e.which > 0 || e.type === "mousedown" || e.type === "mousewheel") {
-            $("#follow-log").prop('checked', false);
+        if (e.which > 0 || e.type === "mousedown" || e.type === "mousewheel" || e.type === "scroll") {
+            const el = this;
+            const atBottom = el.scrollHeight - el.scrollTop <= el.clientHeight + 5;
+            followLog = atBottom;
+            const btn = $('#scroll-to-bottom')[0];
+
+            if(atBottom){
+                btn.setAttribute("hidden", "hidden")
+            }else{
+                const logWindow = document.querySelector('.logWindow');
+                const scrollButton = document.getElementById('scroll-to-bottom');
+
+                // Position the button relative to the scrollbar
+                const scrollbarWidth = logWindow.offsetWidth - logWindow.clientWidth;
+                const rightPosition = scrollbarWidth + 12;
+                scrollButton.style.right = rightPosition + 'px';
+
+                btn.removeAttribute("hidden")
+            }
         }
     });
+
+    $("#scroll-to-bottom").on("click", function () {
+        const el = $('.logWindow')[0];
+        el.scrollTop = el.scrollHeight;
+        followLog = true;
+        this.setAttribute("hidden", "hidden");
+    });
+
 
     formatInitialDates();
     setTimeout(function () {

--- a/edison-jobs/src/main/resources/static/internal/js/logLoader.js
+++ b/edison-jobs/src/main/resources/static/internal/js/logLoader.js
@@ -2,6 +2,25 @@ import {formatUTCToLocalTime, formatUTCToLocalDateTime, formatInitialDates} from
 
 let followLog = true;
 
+export function handleScrollEvent(el, btn) {
+    const atBottom = el.scrollHeight - el.scrollTop <= el.clientHeight + 5;
+    followLog = atBottom;
+
+    if (atBottom) {
+        btn.setAttribute("hidden", "hidden");
+    } else {
+        const scrollbarWidth = el.offsetWidth - el.clientWidth;
+        btn.style.right = (scrollbarWidth + 12) + 'px';
+        btn.removeAttribute("hidden");
+    }
+}
+
+export function handleScrollToBottomClick(el, btn) {
+    el.scrollTop = el.scrollHeight;
+    followLog = true;
+    btn.setAttribute("hidden", "hidden");
+}
+
 export function getLog(logIndex) {
     $.ajax({
         type: "GET",
@@ -78,32 +97,12 @@ export function getLog(logIndex) {
 if (typeof window !== 'undefined' && !window.__testing__) {
     $(".logWindow").bind("scroll mousedown DOMMouseScroll mousewheel keyup", function (e) {
         if (e.which > 0 || e.type === "mousedown" || e.type === "mousewheel" || e.type === "scroll") {
-            const el = this;
-            const atBottom = el.scrollHeight - el.scrollTop <= el.clientHeight + 5;
-            followLog = atBottom;
-            const btn = $('#scroll-to-bottom')[0];
-
-            if(atBottom){
-                btn.setAttribute("hidden", "hidden")
-            }else{
-                const logWindow = document.querySelector('.logWindow');
-                const scrollButton = document.getElementById('scroll-to-bottom');
-
-                // Position the button relative to the scrollbar
-                const scrollbarWidth = logWindow.offsetWidth - logWindow.clientWidth;
-                const rightPosition = scrollbarWidth + 12;
-                scrollButton.style.right = rightPosition + 'px';
-
-                btn.removeAttribute("hidden")
-            }
+            handleScrollEvent(this, $('#scroll-to-bottom')[0]);
         }
     });
 
     $("#scroll-to-bottom").on("click", function () {
-        const el = $('.logWindow')[0];
-        el.scrollTop = el.scrollHeight;
-        followLog = true;
-        this.setAttribute("hidden", "hidden");
+        handleScrollToBottomClick($('.logWindow')[0], this);
     });
 
 

--- a/edison-jobs/src/main/resources/templates/job.html
+++ b/edison-jobs/src/main/resources/templates/job.html
@@ -5,18 +5,18 @@
     <th:block th:replace="~{fragments/head  :: head}"></th:block>
 </head>
 
-<body>
+<body class="d-flex flex-column" style="height: 100dvh; overflow: hidden;">
 
 <div th:replace="~{fragments/navigation  :: navigation}"/>
 
-<div class="container">
-    <div id="job-messages" class="card h-100 mb-4">
+<div class="container flex-grow-1 d-flex flex-column overflow-hidden">
+    <div id="job-messages" class="card flex-grow-1 d-flex flex-column overflow-hidden mb-4">
         <div class="card-header">
             <h3 class="card-title mb-0" th:text="${job.jobType}"></h3>
         </div>
-        <div class="card-body">
-            <div class="container">
-                <div class="row">
+        <div class="card-body d-flex flex-column overflow-hidden">
+            <div class="container d-flex flex-column flex-grow-1 overflow-hidden">
+                <div class="row flex-grow-1 overflow-hidden">
                     <div class="col-md-2">
                         <dl>
                             <dt>Status:</dt>
@@ -62,8 +62,8 @@
                             </button>
                         </div>
                     </div>
-                    <div class="col-md-10">
-                        <div class="card" style="position: relative;">
+                    <div class="col-md-10 d-flex flex-column overflow-hidden">
+                        <div class="card flex-grow-1 d-flex flex-column overflow-hidden" style="position: relative;">
                             <button id="scroll-to-bottom"
                                     style="position: absolute; top: 12px; z-index: 10;"
                                     class="btn btn-sm btn-secondary opacity-75"
@@ -71,7 +71,7 @@
                                     >
                                 Follow log
                             </button>
-                            <pre class="p-2 font-monospace logWindow job-log-scroll"
+                            <pre class="p-2 font-monospace logWindow job-log-scroll d-flex flex-column"
                                  th:attr="data-job-url=${job.jobUri} + '?humanReadable=true'"><div
                                     th:each="message : ${job.getRawMessages()}"><span class="job-messagedate"
                                                                                       th:data-datetime="${message.getTimestampUTCIsoString()}"></span> <span
@@ -94,7 +94,8 @@
 
 <style>
     .job-log-scroll {
-        max-height: calc(100vh - 200px);
+        flex: 1 1 0;
+        min-height: 0;
         overflow-y: auto;
         overflow-x: auto;
         margin-bottom: 0;

--- a/edison-jobs/src/main/resources/templates/job.html
+++ b/edison-jobs/src/main/resources/templates/job.html
@@ -63,16 +63,19 @@
                         </div>
                     </div>
                     <div class="col-md-10">
-                        <div class="form-check text-right">
-                            <input type="checkbox" class="form-check-input" id="follow-log" checked="checked"/>
-                            <label class="form-check-label" for="follow-log">Follow log</label>
-                        </div>
-                        <div class="card">
-                        <pre class="p-2 font-monospace logWindow overflow-auto"
-                             th:attr="data-job-url=${job.jobUri} + '?humanReadable=true'"><div
-                                th:each="message : ${job.getRawMessages()}"><span class="job-messagedate"
-                                                                                  th:data-datetime="${message.getTimestampUTCIsoString()}"></span> <span
-                                th:text="'[' + ${message.getLevel()} + '] ' + ${message.getMessage()}"></span></div></pre>
+                        <div class="card" style="position: relative;">
+                            <button id="scroll-to-bottom"
+                                    style="position: absolute; top: 12px; z-index: 10;"
+                                    class="btn btn-sm btn-secondary opacity-75"
+                                    hidden="hidden"
+                                    >
+                                Follow log
+                            </button>
+                            <pre class="p-2 font-monospace logWindow job-log-scroll"
+                                 th:attr="data-job-url=${job.jobUri} + '?humanReadable=true'"><div
+                                    th:each="message : ${job.getRawMessages()}"><span class="job-messagedate"
+                                                                                      th:data-datetime="${message.getTimestampUTCIsoString()}"></span> <span
+                                    th:text="'[' + ${message.getLevel()} + '] ' + ${message.getMessage()}"></span></div></pre>
                         </div>
                     </div>
                 </div>
@@ -88,4 +91,13 @@
 <script type="module" th:src="@{|${edisonManagementBasePath}/js/logLoader.js|}"></script>
 
 </body>
+
+<style>
+    .job-log-scroll {
+        max-height: calc(100vh - 200px);
+        overflow-y: auto;
+        overflow-x: auto;
+        margin-bottom: 0;
+    }
+</style>
 </html>

--- a/edison-jobs/src/test/js/logLoader.test.js
+++ b/edison-jobs/src/test/js/logLoader.test.js
@@ -10,7 +10,7 @@ globalThis.window.__testing__ = true
 globalThis.formatUTCToLocalTime = (s) => s ?? '-'
 globalThis.formatInitialDates = () => {}
 
-const { getLog } = await import('../../main/resources/static/internal/js/logLoader.js')
+const { getLog, handleScrollEvent, handleScrollToBottomClick } = await import('../../main/resources/static/internal/js/logLoader.js')
 
 const baseData = {
     state: 'Stopped',
@@ -188,5 +188,129 @@ describe('getLog', () => {
         expect($.ajax).toHaveBeenCalledTimes(2)
 
         vi.useRealTimers()
+    })
+})
+
+describe('handleScrollEvent', () => {
+    function makeEl({ scrollHeight, scrollTop, clientHeight, offsetWidth, clientWidth }) {
+        return { scrollHeight, scrollTop, clientHeight, offsetWidth, clientWidth }
+    }
+
+    function makeBtn() {
+        return {
+            _hidden: true,
+            _right: null,
+            style: { right: null },
+            setAttribute(name, value) { if (name === 'hidden') this._hidden = true },
+            removeAttribute(name) { if (name === 'hidden') this._hidden = false },
+        }
+    }
+
+    it('hides the button and sets followLog=true when scrolled to bottom', () => {
+        const el = makeEl({ scrollHeight: 1000, scrollTop: 995, clientHeight: 10, offsetWidth: 20, clientWidth: 20 })
+        const btn = makeBtn()
+
+        handleScrollEvent(el, btn)
+
+        expect(btn._hidden).toBe(true)
+    })
+
+    it('shows the button when not scrolled to bottom', () => {
+        const el = makeEl({ scrollHeight: 1000, scrollTop: 0, clientHeight: 10, offsetWidth: 20, clientWidth: 20 })
+        const btn = makeBtn()
+
+        handleScrollEvent(el, btn)
+
+        expect(btn._hidden).toBe(false)
+    })
+
+    it('positions button right offset accounting for scrollbar width', () => {
+        // offsetWidth=30, clientWidth=20 → scrollbarWidth=10 → right = 10+12 = 22px
+        const el = makeEl({ scrollHeight: 1000, scrollTop: 0, clientHeight: 10, offsetWidth: 30, clientWidth: 20 })
+        const btn = makeBtn()
+
+        handleScrollEvent(el, btn)
+
+        expect(btn.style.right).toBe('22px')
+    })
+
+    it('treats position within 5px of bottom as "at bottom"', () => {
+        // scrollHeight(100) - scrollTop(84) = 16 > clientHeight(10) + 5 = 15 → NOT at bottom
+        const elNotBottom = makeEl({ scrollHeight: 100, scrollTop: 84, clientHeight: 10, offsetWidth: 20, clientWidth: 20 })
+        const btnNotBottom = makeBtn()
+        handleScrollEvent(elNotBottom, btnNotBottom)
+        expect(btnNotBottom._hidden).toBe(false)
+
+        // scrollHeight(100) - scrollTop(85) = 15 <= clientHeight(10) + 5 = 15 → IS at bottom (exactly at margin)
+        const elAtBottom = makeEl({ scrollHeight: 100, scrollTop: 85, clientHeight: 10, offsetWidth: 20, clientWidth: 20 })
+        const btnAtBottom = makeBtn()
+        handleScrollEvent(elAtBottom, btnAtBottom)
+        expect(btnAtBottom._hidden).toBe(true)
+    })
+
+    it('getLog does not auto-scroll when followLog was set to false by scroll event', () => {
+        // Scroll away from bottom → followLog = false
+        const el = makeEl({ scrollHeight: 1000, scrollTop: 0, clientHeight: 10, offsetWidth: 20, clientWidth: 20 })
+        const btn = makeBtn()
+        handleScrollEvent(el, btn)
+
+        // Now getLog should NOT set scrollTop
+        const logWindow = document.querySelector('.logWindow')
+        logWindow.scrollTop = 0
+        $.ajax = vi.fn(({ success }) => success({ ...baseData, messages: ['x'], rawMessages: makeMessages(['x']) }))
+        getLog(0)
+
+        expect(logWindow.scrollTop).toBe(0)
+    })
+})
+
+describe('handleScrollToBottomClick', () => {
+    function makeBtn() {
+        return {
+            _hidden: false,
+            setAttribute(name, value) { if (name === 'hidden') this._hidden = true },
+            removeAttribute(name) { if (name === 'hidden') this._hidden = false },
+        }
+    }
+
+    it('scrolls the element to the bottom and hides the button after click', () => {
+        const el = { scrollHeight: 500, scrollTop: 0 }
+        const btn = makeBtn()
+
+        handleScrollToBottomClick(el, btn)
+
+        expect(el.scrollTop).toBe(500)
+        expect(btn._hidden).toBe(true)
+    })
+
+    it('re-enables auto-scroll (followLog=true) so getLog scrolls again afterwards', () => {
+        // First disable followLog via scroll event (scrollTop=0, far from bottom)
+        const scrollEl = { scrollHeight: 1000, scrollTop: 0, clientHeight: 10, offsetWidth: 20, clientWidth: 20 }
+        const scrollBtn = {
+            _hidden: false,
+            style: { right: null },
+            setAttribute() {},
+            removeAttribute() {},
+        }
+        handleScrollEvent(scrollEl, scrollBtn)
+
+        // Now click scroll-to-bottom → followLog = true again
+        const el = { scrollHeight: 500, scrollTop: 0 }
+        const btn = makeBtn()
+        handleScrollToBottomClick(el, btn)
+
+        // Verify followLog is true again by checking getLog calls scrollTop setter.
+        // JSDOM has no layout engine so scrollHeight is always 0; we spy on the setter instead.
+        const logWindow = document.querySelector('.logWindow')
+        let scrollTopSet = false
+        Object.defineProperty(logWindow, 'scrollTop', {
+            configurable: true,
+            get: () => 0,
+            set: () => { scrollTopSet = true },
+        })
+        $.ajax = vi.fn(({ success }) => success({ ...baseData, messages: ['x'], rawMessages: makeMessages(['x']) }))
+        getLog(0)
+
+        expect(scrollTopSet).toBe(true)
     })
 })

--- a/examples/example-jobs/src/main/java/de/otto/edison/example/jobs/LongJob.java
+++ b/examples/example-jobs/src/main/java/de/otto/edison/example/jobs/LongJob.java
@@ -1,0 +1,56 @@
+package de.otto.edison.example.jobs;
+
+import de.otto.edison.jobs.definition.JobDefinition;
+import de.otto.edison.jobs.domain.JobMarker;
+import de.otto.edison.jobs.eventbus.JobEventPublisher;
+import de.otto.edison.jobs.service.JobRunnable;
+import org.slf4j.Logger;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+import java.util.Random;
+
+import static de.otto.edison.jobs.definition.DefaultJobDefinition.fixedDelayJobDefinition;
+import static java.lang.Thread.sleep;
+import static java.time.Duration.ofHours;
+import static org.slf4j.LoggerFactory.getLogger;
+
+/**
+ * @author Guido Steinacker
+ * @since 15.02.15
+ */
+@Component
+public class LongJob implements JobRunnable {
+
+    private static final Logger LOG = getLogger(LongJob.class);
+
+    @Override
+    public JobDefinition getJobDefinition() {
+        return fixedDelayJobDefinition(
+                "Long",
+                "Long Job",
+                "An example job with JobEventPublisher that is running for a while.",
+                ofHours(1),
+                0,
+                Optional.of(ofHours(3))
+        );
+    }
+
+    @Override
+    public boolean execute(final JobEventPublisher jobEventPublisher) {
+        for (int i = 0; i < 1000; ++i) {
+            doSomeWork(jobEventPublisher,i);
+        }
+        jobEventPublisher.skipped();
+        return true;
+    }
+
+    private void doSomeWork(final JobEventPublisher jobEventPublisher, final int i) {
+        try {
+            jobEventPublisher.info(i + " Still doing some work...");
+            sleep(new Random(42).nextInt(100));
+        } catch (final InterruptedException e) {
+            LOG.error(JobMarker.JOB, e.getMessage());
+        }
+    }
+}

--- a/examples/example-jobs/src/test/java/de/otto/edison/example/ExampleJobsSmokeTest.java
+++ b/examples/example-jobs/src/test/java/de/otto/edison/example/ExampleJobsSmokeTest.java
@@ -77,6 +77,10 @@ public class ExampleJobsSmokeTest {
                 "    \"rel\" : \"http://github.com/otto-de/edison/link-relations/job/definition\",\n" +
                 "    \"title\" : \"Foo Job\"\n" +
                 "  }, {\n" +
+                "    \"href\" : \"http://localhost:" + port + "/exampleContextPath/internal/jobdefinitions/Long\",\n" +
+                "    \"rel\" : \"http://github.com/otto-de/edison/link-relations/job/definition\",\n" +
+                "    \"title\" : \"Long Job\"\n" +
+                "  }, {\n" +
                 "    \"href\" : \"http://localhost:" + port + "/exampleContextPath/internal/jobdefinitions/Old\",\n" +
                 "    \"rel\" : \"http://github.com/otto-de/edison/link-relations/job/definition\",\n" +
                 "    \"title\" : \"Old Job\"\n" +


### PR DESCRIPTION
Previously, the log output on the job page could grow beyond the page height, requiring the user to scroll the entire page.

Changes:

- The log container now has a fixed size, regardless of the number of log messages
- If the log exceeds the visible area, scrolling is handled within the container instead of the whole page
- Added a "Scroll to Bottom" button for quick navigation to the latest log entry

Before:

<img width="1429" height="1327" alt="Bildschirmfoto 2026-06-19 um 13 13 54" src="https://github.com/user-attachments/assets/1d40922d-07cb-4260-82bd-4c3f70bb9205" />

After:

<img width="1358" height="1329" alt="Bildschirmfoto 2026-06-19 um 13 17 05" src="https://github.com/user-attachments/assets/dd3c6005-f94f-45e6-9d81-f84f9b37965e" />
